### PR TITLE
Add path to solr directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In the web UI if you click on "Core Admin" you should now see the "gettingstarte
 If you want to load some example data:
 
 ```console
-$ docker exec -it --user=solr my_solr bin/post -c gettingstarted example/exampledocs/manufacturers.xml
+$ docker exec -it --user=solr my_solr bin/post -c gettingstarted /opt/solr/example/exampledocs/manufacturers.xml
 ```
 
 In the UI, find the "Core selector" popup menu and select the "gettingstarted" core, then select the "Query" menu item. This gives you a default search for "*:*" which returns all docs. Hit the "Execute Query" button, and you should see a few docs with data. Congratulations!


### PR DESCRIPTION
I was running through the directions and there was one hitch loading the sample data. Here was the error returned:

```
sudo docker exec -it --user=solr my_solr bin/post -c gettingstarted example/exampledocs/manufacturers.xm 
Unrecognized argument: example/exampledocs/manufacturers.xm

If this was intended to be a data file, it does not exist relative to /opt/solr
```

After updating the command so that it was referencing the `manufacturers.xml` within the solr directory this worked:

```
sudo docker exec -it --user=solr my_solr bin/post -c gettingstarted /opt/solr/example/exampledocs/manufacturers.xml
java -classpath /opt/solr/dist/solr-core-5.4.0.jar -Dauto=yes -Dc=gettingstarted -Ddata=files org.apache.solr.util.SimplePostTool /opt/solr/example/exampledocs/manufacturers.xml
SimplePostTool version 5.0.0
Posting files to [base] url http://localhost:8983/solr/gettingstarted/update...
Entering auto mode. File endings considered are xml,json,csv,pdf,doc,docx,ppt,pptx,xls,xlsx,odt,odp,ods,ott,otp,ots,rtf,htm,html,txt,log
POSTing file manufacturers.xml (application/xml) to [base]
1 files indexed.
COMMITting Solr index changes to http://localhost:8983/solr/gettingstarted/update...
Time spent: 0:00:00.506
```
