### PR TITLE
Remove docs/ (82.5MB)

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -41,6 +41,7 @@ RUN mkdir -p /opt/solr && \
   gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \
   tar -C /opt/solr --extract --file /opt/solr.tgz --strip-components=1 && \
   rm /opt/solr.tgz* && \
+  rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -36,6 +36,7 @@ RUN mkdir -p /opt/solr && \
   gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \
   tar -C /opt/solr --extract --file /opt/solr.tgz --strip-components=1 && \
   rm /opt/solr.tgz* && \
+  rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \


### PR DESCRIPTION
Lets keep the images lean, please.

Maybe there's something to be said about removing dist/* & contrib/* as well... perhaps only on the alpine image.  Someone who chooses Alpine wants lean-ness.