### PR TITLE
Issue57 solr download server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,4 @@ before_install:
 - docker pull java:openjdk-8-jre-alpine
 
 script:
-- bash -c "export | grep SOLR_DOWNLOAD_SERVER"
 - bash build-all.sh versions build_all test_all push_all

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ before_install:
 - docker pull java:openjdk-8-jre-alpine
 
 script:
+- bash -c "export | grep SOLR_DOWNLOAD_SERVER"
 - bash build-all.sh versions build_all test_all push_all

--- a/5.3/alpine/Dockerfile
+++ b/5.3/alpine/Dockerfile
@@ -34,8 +34,10 @@ ENV SOLR_SHA256 7c26601229ed712c639d00882f35304d87e0032028be4754d098a9b694877f48
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget $SOLR_URL -O /opt/solr.tgz && \
-  wget $SOLR_URL.asc -O /opt/solr.tgz.asc && \
+  echo "downloading $SOLR_URL" && \
+  wget -q $SOLR_URL -O /opt/solr.tgz && \
+  echo "downloading $SOLR_URL.asc" && \
+  wget -q $SOLR_URL.asc -O /opt/solr.tgz.asc && \
   echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \
   (>&2 ls -l /opt/solr.tgz /opt/solr.tgz.asc) && \
   gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \

--- a/5.4/alpine/Dockerfile
+++ b/5.4/alpine/Dockerfile
@@ -34,8 +34,10 @@ ENV SOLR_SHA256 3e4b4ec7bd728b49b2ebc3dbe8f3d1ef89fded4ab86b9e2f856bedd58c99f28b
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget $SOLR_URL -O /opt/solr.tgz && \
-  wget $SOLR_URL.asc -O /opt/solr.tgz.asc && \
+  echo "downloading $SOLR_URL" && \
+  wget -q $SOLR_URL -O /opt/solr.tgz && \
+  echo "downloading $SOLR_URL.asc" && \
+  wget -q $SOLR_URL.asc -O /opt/solr.tgz.asc && \
   echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \
   (>&2 ls -l /opt/solr.tgz /opt/solr.tgz.asc) && \
   gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \

--- a/5.5/alpine/Dockerfile
+++ b/5.5/alpine/Dockerfile
@@ -34,8 +34,10 @@ ENV SOLR_SHA256 e62bab565675e10d27f40d5bb090b4181b2f0c21870adf98d1ea873ead7758e1
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget $SOLR_URL -O /opt/solr.tgz && \
-  wget $SOLR_URL.asc -O /opt/solr.tgz.asc && \
+  echo "downloading $SOLR_URL" && \
+  wget -q $SOLR_URL -O /opt/solr.tgz && \
+  echo "downloading $SOLR_URL.asc" && \
+  wget -q $SOLR_URL.asc -O /opt/solr.tgz.asc && \
   echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \
   (>&2 ls -l /opt/solr.tgz /opt/solr.tgz.asc) && \
   gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \

--- a/6.0/alpine/Dockerfile
+++ b/6.0/alpine/Dockerfile
@@ -34,8 +34,10 @@ ENV SOLR_SHA256 4fd25942f0b8083a2499e1dc606c6dd29e4b520c28a16a2d82111088126d43af
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget $SOLR_URL -O /opt/solr.tgz && \
-  wget $SOLR_URL.asc -O /opt/solr.tgz.asc && \
+  echo "downloading $SOLR_URL" && \
+  wget -q $SOLR_URL -O /opt/solr.tgz && \
+  echo "downloading $SOLR_URL.asc" && \
+  wget -q $SOLR_URL.asc -O /opt/solr.tgz.asc && \
   echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \
   (>&2 ls -l /opt/solr.tgz /opt/solr.tgz.asc) && \
   gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \

--- a/6.1/alpine/Dockerfile
+++ b/6.1/alpine/Dockerfile
@@ -34,8 +34,10 @@ ENV SOLR_SHA256 74630a06d45eb44c0afe2bfb6e2cd80c9d8d92aa0c48a563e39c32996a76c8b0
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget $SOLR_URL -O /opt/solr.tgz && \
-  wget $SOLR_URL.asc -O /opt/solr.tgz.asc && \
+  echo "downloading $SOLR_URL" && \
+  wget -q $SOLR_URL -O /opt/solr.tgz && \
+  echo "downloading $SOLR_URL.asc" && \
+  wget -q $SOLR_URL.asc -O /opt/solr.tgz.asc && \
   echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \
   (>&2 ls -l /opt/solr.tgz /opt/solr.tgz.asc) && \
   gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \

--- a/6.2/alpine/Dockerfile
+++ b/6.2/alpine/Dockerfile
@@ -34,8 +34,10 @@ ENV SOLR_SHA256 ba7c93e1c8d28717d6d84788ebdc2e8e9211a32f48b5a30b2a904762a0b7cd39
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget $SOLR_URL -O /opt/solr.tgz && \
-  wget $SOLR_URL.asc -O /opt/solr.tgz.asc && \
+  echo "downloading $SOLR_URL" && \
+  wget -q $SOLR_URL -O /opt/solr.tgz && \
+  echo "downloading $SOLR_URL.asc" && \
+  wget -q $SOLR_URL.asc -O /opt/solr.tgz.asc && \
   echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \
   (>&2 ls -l /opt/solr.tgz /opt/solr.tgz.asc) && \
   gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -34,8 +34,10 @@ ENV SOLR_SHA256 "checksum-goes-here"
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget $SOLR_URL -O /opt/solr.tgz && \
-  wget $SOLR_URL.asc -O /opt/solr.tgz.asc && \
+  echo "downloading $SOLR_URL" && \
+  wget -q $SOLR_URL -O /opt/solr.tgz && \
+  echo "downloading $SOLR_URL.asc" && \
+  wget -q $SOLR_URL.asc -O /opt/solr.tgz.asc && \
   echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \
   (>&2 ls -l /opt/solr.tgz /opt/solr.tgz.asc) && \
   gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \

--- a/build-all.sh
+++ b/build-all.sh
@@ -82,10 +82,10 @@ function build {
   cat > $build_dir/build.sh <<EOM
 #!/bin/bash
 set -e
-if [ ! -z "$SOLR_DOWNLOAD_SERVER" ]; then
-  build_arg="--build-arg SOLR_DOWNLOAD_SERVER=$SOLR_DOWNLOAD_SERVER"
+if [ ! -z "\$SOLR_DOWNLOAD_SERVER" ]; then
+  build_arg="--build-arg SOLR_DOWNLOAD_SERVER=\$SOLR_DOWNLOAD_SERVER"
 fi
-cmd="docker build --pull --rm=true $build_arg --tag $tag ."
+cmd="docker build --pull --rm=true \$build_arg --tag $tag ."
 echo "running: \$cmd"
 \$cmd
 for t in $tags; do

--- a/update.sh
+++ b/update.sh
@@ -14,8 +14,8 @@ GPG_KEYSERVER=${GPG_KEYSERVER:-hkp://pool.sks-keyservers.net}
 
 versions=( "$@" )
 if [ ${#versions[@]} -eq 0 ]; then
-	echo "Usage: bash update.sh [version ...]"
-	exit 1
+    echo "Usage: bash update.sh [version ...]"
+    exit 1
 fi
 versions=( "${versions[@]%/}" )
 
@@ -52,75 +52,75 @@ curl -sSL $archiveUrl | sed -r -e 's,.*<a href="(([0-9])+\.([0-9])+\.([0-9])+)/"
 
 mkdir -p $DOWNLOADS
 for version in "${versions[@]}"; do
-	full_version="$(grep "^$version" "$upstream_versions" | tail -n 1)"
-	if [[ -z $full_version ]]; then
-		echo "Cannot find $version in $archiveUrl"
-		exit 1
-	fi
-	(
-		set -x
+    full_version="$(grep "^$version" "$upstream_versions" | tail -n 1)"
+    if [[ -z $full_version ]]; then
+        echo "Cannot find $version in $archiveUrl"
+        exit 1
+    fi
+    (
+        set -x
 
-                cd $DOWNLOADS
+        cd $DOWNLOADS
 
-		# get the tgz, so we can checksum it, and verify the signature
-		output=solr-$full_version.tgz
-		partial_url=$full_version/solr-$full_version.tgz
-		if [ ! -f solr-$full_version.tgz ]; then
-			if ! wget -nv --output-document=$output $archiveUrl/$partial_url; then
-				echo "Could not fetch $archiveUrl/$partial_url"
-				exit 1
-			fi
-		fi
+        # get the tgz, so we can checksum it, and verify the signature
+        output=solr-$full_version.tgz
+        partial_url=$full_version/solr-$full_version.tgz
+        if [ ! -f solr-$full_version.tgz ]; then
+            if ! wget -nv --output-document=$output $archiveUrl/$partial_url; then
+                echo "Could not fetch $archiveUrl/$partial_url"
+                exit 1
+            fi
+        fi
 
-		# The Solr release process publish MD5 and SHA1 checksum files. Check those first so we get a clear
-		# early failure for incomplete downloads, and avoid scary-sounding PGP mismatches
-		if [ ! -f solr-$full_version.tgz.sha1 ]; then
-			wget -nv --output-document=solr-$full_version.tgz.sha1 $archiveUrl/$full_version/solr-$full_version.tgz.sha1
-		fi
-		sha1sum -c solr-$full_version.tgz.sha1
-		if [ ! -f solr-$full_version.tgz.md5 ]; then
-			wget -nv --output-document=solr-$full_version.tgz.md5 $archiveUrl/$full_version/solr-$full_version.tgz.md5
-		fi
-		md5sum -c solr-$full_version.tgz.md5
+        # The Solr release process publish MD5 and SHA1 checksum files. Check those first so we get a clear
+        # early failure for incomplete downloads, and avoid scary-sounding PGP mismatches
+        if [ ! -f solr-$full_version.tgz.sha1 ]; then
+            wget -nv --output-document=solr-$full_version.tgz.sha1 $archiveUrl/$full_version/solr-$full_version.tgz.sha1
+        fi
+        sha1sum -c solr-$full_version.tgz.sha1
+        if [ ! -f solr-$full_version.tgz.md5 ]; then
+            wget -nv --output-document=solr-$full_version.tgz.md5 $archiveUrl/$full_version/solr-$full_version.tgz.md5
+        fi
+        md5sum -c solr-$full_version.tgz.md5
 
-		# We will record a stronger SHA256
-		SHA256=$(sha256sum solr-$full_version.tgz | awk '{print $1}')
+        # We will record a stronger SHA256
+        SHA256=$(sha256sum solr-$full_version.tgz | awk '{print $1}')
 
-		# get the PGP signature
-		if [ ! -f solr-$full_version.tgz.asc ]; then
-			wget -nv --output-document=solr-$full_version.tgz.asc $archiveUrl/$full_version/solr-$full_version.tgz.asc
-		fi
+        # get the PGP signature
+        if [ ! -f solr-$full_version.tgz.asc ]; then
+            wget -nv --output-document=solr-$full_version.tgz.asc $archiveUrl/$full_version/solr-$full_version.tgz.asc
+        fi
 
-		# Get the code signing keys
-		# Per http://www.apache.org/dyn/closer.html and a message from Hoss on
-		# http://stackoverflow.com/questions/32539810/apache-lucene-5-3-0-release-keys-missing-key-3fcfdb3e
-		wget -nv --output-document KEYS $archiveUrl/$full_version/KEYS
-		gpg --import KEYS
+        # Get the code signing keys
+        # Per http://www.apache.org/dyn/closer.html and a message from Hoss on
+        # http://stackoverflow.com/questions/32539810/apache-lucene-5-3-0-release-keys-missing-key-3fcfdb3e
+        wget -nv --output-document KEYS $archiveUrl/$full_version/KEYS
+        gpg --import KEYS
 
-		# and for some extra verification we check the key on the keyserver too:
-		KEY=$(gpg --status-fd 1 --batch --verify solr-$full_version.tgz.asc solr-$full_version.tgz 2>&1 | awk '$1 == "[GNUPG:]" && ($2 == "BADSIG" || $2 == "VALIDSIG") { print $3; exit }')
-		gpg --keyserver "$GPG_KEYSERVER" --recv-key "$KEY" || {
-                    echo "Failed to get the key from the key server"
-                    exit 1
-                }
+        # and for some extra verification we check the key on the keyserver too:
+        KEY=$(gpg --status-fd 1 --batch --verify solr-$full_version.tgz.asc solr-$full_version.tgz 2>&1 | awk '$1 == "[GNUPG:]" && ($2 == "BADSIG" || $2 == "VALIDSIG") { print $3; exit }')
+        gpg --keyserver "$GPG_KEYSERVER" --recv-key "$KEY" || {
+            echo "Failed to get the key from the key server"
+            exit 1
+        }
 
-		# verify the signature matches our content
-		gpg --batch --verify solr-$full_version.tgz.asc solr-$full_version.tgz
-		# get the full fingerprint (since we only get the "long id" if it was BADSIG before)
-		KEY=$(gpg --status-fd 1 --batch --verify solr-$full_version.tgz.asc solr-$full_version.tgz 2>&1 | awk '$1 == "[GNUPG:]" && $2 == "VALIDSIG" { print $3; exit }')
+        # verify the signature matches our content
+        gpg --batch --verify solr-$full_version.tgz.asc solr-$full_version.tgz
+        # get the full fingerprint (since we only get the "long id" if it was BADSIG before)
+        KEY=$(gpg --status-fd 1 --batch --verify solr-$full_version.tgz.asc solr-$full_version.tgz 2>&1 | awk '$1 == "[GNUPG:]" && $2 == "VALIDSIG" { print $3; exit }')
 
-		if [ -z "$KEEP_ALL_ARTIFACTS" ]; then
-			rm solr-$full_version.tgz.asc solr-$full_version.tgz.sha1 solr-$full_version.tgz.md5
-			if [ -z "$KEEP_SOLR_ARTIFACT" ]; then
-				rm solr-$full_version.tgz
-			fi
-		fi
+        if [ -z "$KEEP_ALL_ARTIFACTS" ]; then
+            rm solr-$full_version.tgz.asc solr-$full_version.tgz.sha1 solr-$full_version.tgz.md5
+            if [ -z "$KEEP_SOLR_ARTIFACT" ]; then
+                rm solr-$full_version.tgz
+            fi
+        fi
 
-                cd ..
+        cd ..
 
-	        write_files $full_version
-	        write_files $full_version 'alpine'
-	)
+        write_files $full_version
+        write_files $full_version 'alpine'
+    )
 done
 
 if [ -f $DOWNLOADS/KEYS ]; then rm $DOWNLOADS/KEYS; fi

--- a/update.sh
+++ b/update.sh
@@ -65,11 +65,21 @@ for version in "${versions[@]}"; do
         # get the tgz, so we can checksum it, and verify the signature
         output=solr-$full_version.tgz
         partial_url=$full_version/solr-$full_version.tgz
-        if [ ! -f solr-$full_version.tgz ]; then
-            if ! wget -nv --output-document=$output $archiveUrl/$partial_url; then
-                echo "Could not fetch $archiveUrl/$partial_url"
-                exit 1
+        download_urls=()
+        if [[ ! -z "$SOLR_DOWNLOAD_SERVER" ]]; then
+            download_urls+=("$SOLR_DOWNLOAD_SERVER/$partial_url")
+        fi
+        download_urls+=("$archiveUrl/$partial_url")
+        for download_url in $download_urls; do
+            echo "Fetching $download_url"
+            if wget -nv --output-document=$output $download_url; then
+                download_url_used=$download_url
+            else
+                echo "Could not fetch $download_url"
             fi
+        done
+        if [[ -z "$download_url_used" ]]; then
+            exit 1
         fi
 
         # The Solr release process publish MD5 and SHA1 checksum files. Check those first so we get a clear


### PR DESCRIPTION
Let SOLR_DOWNLOAD_SERVER override the solr archive URL in update.sh.

I've changed the travis config to set SOLR_DOWNLOAD_SERVER, pointing to a private mirror, so that the Dockerfiles will use that, during a build. That does mean I now have a mirror to maintain, and that's not automated yet, which I'd like to do before merging this.

For https://github.com/docker-solr/docker-solr/issues/57

I also did some indentation cleanup and reduced logging output for wget on alpine.