### PR TITLE
Add procps to alpine images

### DIFF
--- a/5.3/alpine/Dockerfile
+++ b/5.3/alpine/Dockerfile
@@ -13,6 +13,7 @@ ARG GPG_KEYSERVER
 RUN apk add --no-cache \
         lsof \
         gnupg \
+        procps \
         tar \
         bash
 RUN apk add --no-cache ca-certificates wget && \

--- a/5.4/alpine/Dockerfile
+++ b/5.4/alpine/Dockerfile
@@ -13,6 +13,7 @@ ARG GPG_KEYSERVER
 RUN apk add --no-cache \
         lsof \
         gnupg \
+        procps \
         tar \
         bash
 RUN apk add --no-cache ca-certificates wget && \

--- a/5.5/alpine/Dockerfile
+++ b/5.5/alpine/Dockerfile
@@ -13,6 +13,7 @@ ARG GPG_KEYSERVER
 RUN apk add --no-cache \
         lsof \
         gnupg \
+        procps \
         tar \
         bash
 RUN apk add --no-cache ca-certificates wget && \

--- a/6.0/alpine/Dockerfile
+++ b/6.0/alpine/Dockerfile
@@ -13,6 +13,7 @@ ARG GPG_KEYSERVER
 RUN apk add --no-cache \
         lsof \
         gnupg \
+        procps \
         tar \
         bash
 RUN apk add --no-cache ca-certificates wget && \

--- a/6.1/alpine/Dockerfile
+++ b/6.1/alpine/Dockerfile
@@ -13,6 +13,7 @@ ARG GPG_KEYSERVER
 RUN apk add --no-cache \
         lsof \
         gnupg \
+        procps \
         tar \
         bash
 RUN apk add --no-cache ca-certificates wget && \

--- a/6.2/alpine/Dockerfile
+++ b/6.2/alpine/Dockerfile
@@ -13,6 +13,7 @@ ARG GPG_KEYSERVER
 RUN apk add --no-cache \
         lsof \
         gnupg \
+        procps \
         tar \
         bash
 RUN apk add --no-cache ca-certificates wget && \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -13,6 +13,7 @@ ARG GPG_KEYSERVER
 RUN apk add --no-cache \
         lsof \
         gnupg \
+        procps \
         tar \
         bash
 RUN apk add --no-cache ca-certificates wget && \


### PR DESCRIPTION
Adding this package installs the POSIX versions of several [tools](https://pkgs.alpinelinux.org/contents?branch=edge&name=procps&arch=aarch64&repo=main) that the Solr scripts rely on. They are broken otherwise.

Before:
```
bash-4.3$ solr start
Waiting up to 30 seconds to see Solr running on port 8983bash-4.3$
Started Solr server on port 8983 (pid=solr). Happy searching!


bash-4.3$ solr stop
Sending stop command to Solr running on port 8983 ... waiting 5 seconds to allow Jetty process solr to stop gracefully.
Solr process solr is still running; forcefully killing it now.
/opt/solr/bin/solr: line 564: kill: solr: arguments must be process or job IDs
Killed process solr
ERROR: Failed to kill previous Solr Java process solr ... script fails.
bash-4.3$
```

After:
```
bash-4.3$ solr start
Waiting up to 30 seconds to see Solr running on port 8983 [-]
Started Solr server on port 8983 (pid=52). Happy searching!

bash-4.3$ solr stop
Sending stop command to Solr running on port 8983 ... waiting 5 seconds to allow Jetty process 52 to stop gracefully.
```