### PR TITLE
Change default CONFIG_SOURCE to upstream default

### DIFF
--- a/5.3/alpine/scripts/docker-entrypoint.sh
+++ b/5.3/alpine/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"

--- a/5.3/scripts/docker-entrypoint.sh
+++ b/5.3/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"

--- a/5.4/alpine/scripts/docker-entrypoint.sh
+++ b/5.4/alpine/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"

--- a/5.4/scripts/docker-entrypoint.sh
+++ b/5.4/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"

--- a/5.5/alpine/scripts/docker-entrypoint.sh
+++ b/5.5/alpine/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"

--- a/5.5/scripts/docker-entrypoint.sh
+++ b/5.5/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"

--- a/6.0/alpine/scripts/docker-entrypoint.sh
+++ b/6.0/alpine/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"

--- a/6.0/scripts/docker-entrypoint.sh
+++ b/6.0/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"

--- a/6.1/alpine/scripts/docker-entrypoint.sh
+++ b/6.1/alpine/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"

--- a/6.1/scripts/docker-entrypoint.sh
+++ b/6.1/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"

--- a/6.2/alpine/scripts/docker-entrypoint.sh
+++ b/6.2/alpine/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"

--- a/6.2/scripts/docker-entrypoint.sh
+++ b/6.2/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ so should be reliable.
 
 The second way of creating a core at start time is using the `solr-precreate` command. This will create the core
 in the filesystem before running Solr. You should pass it the core name, and optionally the directory to copy the
-config from (this defaults to Solr's built-in "basic_configs"). For example:
+config from (this defaults to Solr's built-in "data_driven_schema_configs"). For example:
 
 ```console
 $ docker run -d -P solr solr-precreate mycore
@@ -126,7 +126,7 @@ $ docker run -d -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precr
 ```
 
 This second way is quicker, easier to monitor because it logs to the docker log, and can fail immediately if something is wrong.
-But, because it makes assumptions about Solr's "basic_configs", future upstream changes could break that.
+But, because it makes assumptions about Solr's "data_driven_schema_configs", future upstream changes could break that.
 
 The third way of creating a core at startup is to use the image extension mechanism explained in the next section.
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -93,7 +93,7 @@ elif [[ "$1" = 'solr-precreate' ]]; then
     #      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
     echo "Executing $1 command"
     CORE=${2:-gettingstarted}
-    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/basic_configs'}
+    CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir
     coredir="$coresdir/$CORE"


### PR DESCRIPTION
docker-solr uses `basic_configs` as the default config source (see https://github.com/docker-solr/docker-solr/blob/master/6.2/scripts/docker-entrypoint.sh#L96), however the upstream default is `data_driven_schema_configs` (see https://github.com/apache/lucene-solr/blob/branch_6_2/solr/bin/solr#L751 - it has been like this at least since Solr 5.4).

As the result, Solr cores created with `docker run ... solr-precreate <core>` behave differently from those created locally with `solr create -c <core>`.

This PR fixes the inconsistency.