### PR TITLE
Make "solr zk" work

### DIFF
--- a/5.3/Dockerfile
+++ b/5.3/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/5.3/alpine/Dockerfile
+++ b/5.3/alpine/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/5.3/alpine/scripts/docker-entrypoint.sh
+++ b/5.3/alpine/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob

--- a/5.3/scripts/docker-entrypoint.sh
+++ b/5.3/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob

--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/5.4/alpine/Dockerfile
+++ b/5.4/alpine/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/5.4/alpine/scripts/docker-entrypoint.sh
+++ b/5.4/alpine/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob

--- a/5.4/scripts/docker-entrypoint.sh
+++ b/5.4/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/5.5/alpine/Dockerfile
+++ b/5.5/alpine/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/5.5/alpine/scripts/docker-entrypoint.sh
+++ b/5.5/alpine/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob

--- a/5.5/scripts/docker-entrypoint.sh
+++ b/5.5/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/6.0/alpine/Dockerfile
+++ b/6.0/alpine/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/6.0/alpine/scripts/docker-entrypoint.sh
+++ b/6.0/alpine/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob

--- a/6.0/scripts/docker-entrypoint.sh
+++ b/6.0/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob

--- a/6.1/Dockerfile
+++ b/6.1/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/6.1/alpine/Dockerfile
+++ b/6.1/alpine/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/6.1/alpine/scripts/docker-entrypoint.sh
+++ b/6.1/alpine/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob

--- a/6.1/scripts/docker-entrypoint.sh
+++ b/6.1/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/6.2/alpine/Dockerfile
+++ b/6.2/alpine/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/6.2/alpine/scripts/docker-entrypoint.sh
+++ b/6.2/alpine/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob

--- a/6.2/scripts/docker-entrypoint.sh
+++ b/6.2/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob

--- a/Docker-FAQ.md
+++ b/Docker-FAQ.md
@@ -122,6 +122,32 @@ docker exec -it --user=solr $SOLR_CONTAINER curl http://localhost:8983/solr/gett
 ```
 
 
+Can I use volumes with SOLR_HOME?
+---------------------------------
+
+Outside docker-solr, it is common to use the SOLR_HOME environment variable to point to a different volume for
+storing data. You can do that in docker-solr too. Like in plain Solr, you have to provide a `solr.xml` in that
+location, and in most cases the configsets too. In docker-solr it's easy to copy the defaults in place:
+
+```
+mkdir mysolrhome
+sudo chown 8983:8983 mysolrhome
+docker run -it -v $PWD/mysolrhome:/mysolrhome solr \
+    bash -c "cp -R /opt/solr/server/solr/* /mysolrhome"
+docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome solr
+```
+
+Or if you want to do it in a single command (perhaps for Docker Compose):
+
+```
+docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome solr \
+    bash -c "cp -R /opt/solr/server/solr/* /mysolrhome && exec solr -f"
+```
+
+Personally I'm not a fan of this approach; I prefer to keep the Solr home in its
+default location, and if necessary mount a prepared volume at that location.
+
+
 Can I run ZooKeeper and Solr clusters under Docker?
 ---------------------------------------------------
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Then with a web browser go to `http://localhost:8983/` to see the Admin Console 
 To use Solr, you need to create a "core", an index for your data. For example:
 
 ```console
-$ docker exec -it --user=solr my_solr bin/solr create_core -c gettingstarted
+$ docker exec -it --user=solr my_solr solr create_core -c gettingstarted
 ```
 
 In the web UI if you click on "Core Admin" you should now see the "gettingstarted" core.
@@ -46,7 +46,7 @@ In the web UI if you click on "Core Admin" you should now see the "gettingstarte
 If you want to load some of the example data that is included in the container:
 
 ```console
-$ docker exec -it --user=solr my_solr bin/post -c gettingstarted example/exampledocs/manufacturers.xml
+$ docker exec -it --user=solr my_solr post -c gettingstarted example/exampledocs/manufacturers.xml
 ```
 
 In the UI, find the "Core selector" popup menu and select the "gettingstarted" core, then select the "Query" menu item. This gives you a default search for `*:*` which returns all docs. Hit the "Execute Query" button, and you should see a few docs with data. Congratulations!
@@ -65,15 +65,15 @@ If you want load your own data, you'll have to make it available to the containe
 
 ```console
 $ docker cp $HOME/mydata/mydata.xml my_solr:/opt/solr/mydata.xml
-$ docker exec -it --user=solr my_solr bin/post -c gettingstarted mydata.xml
+$ docker exec -it --user=solr my_solr post -c gettingstarted mydata.xml
 ```
 
 or by using Docker host volumes:
 
 ```console
 $ docker run --name my_solr -d -p 8983:8983 -t -v $HOME/mydata:/opt/solr/mydata solr
-$ docker exec -it --user=solr my_solr bin/solr create_core -c gettingstarted
-$ docker exec -it --user=solr my_solr bin/post -c gettingstarted mydata/mydata.xml
+$ docker exec -it --user=solr my_solr solr create_core -c gettingstarted
+$ docker exec -it --user=solr my_solr post -c gettingstarted mydata/mydata.xml
 ```
 
 To learn more about Solr, see the [Apache Solr Reference Guide](https://cwiki.apache.org/confluence/display/solr/Apache+Solr+Reference+Guide).

--- a/build-all.sh
+++ b/build-all.sh
@@ -210,6 +210,13 @@ function push {
 
 function push_all {
   if [[ $TRAVIS = 'true' ]]; then
+    for e in TRAVIS_BRANCH TRAVIS_COMMIT TRAVIS_PULL_REQUEST TRAVIS_PULL_REQUEST_BRANCH TRAVIS_PULL_REQUEST_SHA TRAVIS_REPO_SLUG; do
+      eval "echo $e=\${$e}"
+    done
+    if [[ $TRAVIS_REPO_SLUG != 'docker-solr/docker-solr' ]]; then
+      echo "Not pushing because this is not the docker-solr/docker-solr repo"
+      return
+    fi
     if [[ $TRAVIS_PULL_REQUEST != 'false' ]]; then
       echo "Not pushing because this is a pull request"
       return

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -39,7 +39,7 @@ function initial_solr_end {
     echo "Running Solr in the foreground"
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     # execute files in /docker-entrypoint-initdb.d before starting solr
     # for an example see docs/set-heap.sh
     shopt -s nullglob


### PR DESCRIPTION
Change the default CMD to "solr-foreground", and run solr with `-f` only for that.

For example:

To run an arbitrary command:

```
docker run -it solr /bin/date
```

To run solr in the foreground without arguments:

```
docker run -it solr
```

To run solr in the foreground with extra arguments:

```
docker run -it solr -h myhostname
```

To run solr as an arbitrary command:

```
docker run -it solr solr zk --help
```

Fixes https://github.com/docker-solr/docker-solr/issues/71
