### PR TITLE
Dockerfile: add VOLUME for solr home dir

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -56,6 +56,8 @@ RUN chown -R $SOLR_USER:$SOLR_USER /opt/docker-solr
 
 ENV PATH /opt/solr/bin:/opt/docker-solr/scripts:$PATH
 
+VOLUME /opt/solr/server/solr/
+
 EXPOSE 8983
 WORKDIR /opt/solr
 USER $SOLR_USER

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -48,6 +48,8 @@ RUN chown -R $SOLR_USER:$SOLR_USER /opt/docker-solr
 
 ENV PATH /opt/solr/bin:/opt/docker-solr/scripts:$PATH
 
+VOLUME /opt/solr/server/solr/
+
 EXPOSE 8983
 WORKDIR /opt/solr
 USER $SOLR_USER


### PR DESCRIPTION
It's useful metadata to declare the volume.  Other stateful services do this (e.g. Zookeeper docker images).  

Until recently I've yet to figure out what effect setting the VOLUME has without expressly mapping it.  Today I found one such effect in my use of Kontena.  It is unable to automatically create a data container for the service (declared to be stateful) because there are no volume paths to put in it.