### PR TITLE
Make "solr zk" work

### DIFF
--- a/5.3/Dockerfile
+++ b/5.3/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/5.3/alpine/Dockerfile
+++ b/5.3/alpine/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/5.3/alpine/scripts/docker-entrypoint.sh
+++ b/5.3/alpine/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then

--- a/5.3/scripts/docker-entrypoint.sh
+++ b/5.3/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then

--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/5.4/alpine/Dockerfile
+++ b/5.4/alpine/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/5.4/alpine/scripts/docker-entrypoint.sh
+++ b/5.4/alpine/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then

--- a/5.4/scripts/docker-entrypoint.sh
+++ b/5.4/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/5.5/alpine/Dockerfile
+++ b/5.5/alpine/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/5.5/alpine/scripts/docker-entrypoint.sh
+++ b/5.5/alpine/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then

--- a/5.5/scripts/docker-entrypoint.sh
+++ b/5.5/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/6.0/alpine/Dockerfile
+++ b/6.0/alpine/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/6.0/alpine/scripts/docker-entrypoint.sh
+++ b/6.0/alpine/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then

--- a/6.0/scripts/docker-entrypoint.sh
+++ b/6.0/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then

--- a/6.1/Dockerfile
+++ b/6.1/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/6.1/alpine/Dockerfile
+++ b/6.1/alpine/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/6.1/alpine/scripts/docker-entrypoint.sh
+++ b/6.1/alpine/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then

--- a/6.1/scripts/docker-entrypoint.sh
+++ b/6.1/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/6.2/alpine/Dockerfile
+++ b/6.2/alpine/Dockerfile
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/6.2/alpine/scripts/docker-entrypoint.sh
+++ b/6.2/alpine/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then

--- a/6.2/scripts/docker-entrypoint.sh
+++ b/6.2/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then

--- a/Docker-FAQ.md
+++ b/Docker-FAQ.md
@@ -18,11 +18,11 @@ For some use-cases it is convenient to provide a modified `solr.in.sh` file to S
 For example to point Solr to a ZooKeeper host:
 
 ```
-docker create --name my-solr -P solr
-docker cp my-solr:/opt/solr/bin/solr.in.sh .
+docker create --name my_solr -P solr
+docker cp my_solr:/opt/solr/bin/solr.in.sh .
 sed -i -e 's/#ZK_HOST=.*/ZK_HOST=cylon.lan:2181/' solr.in.sh
-docker cp solr.in.sh my-solr:/opt/solr/bin/solr.in.sh
-docker start my-solr
+docker cp solr.in.sh my_solr:/opt/solr/bin/solr.in.sh
+docker start my_solr
 # With a browser go to http://cylon.lan:32873/solr/#/ and confirm "-DzkHost=cylon.lan:2181" in the JVM Args section.
 ```
 
@@ -61,7 +61,7 @@ $ docker run -it --rm -v /home/docker-volumes/mysolr1:/target solr cp -r server/
 $ SOLR_CONTAINER=$(docker run -d -P -v /home/docker-volumes/mysolr1/solr:/opt/solr/server/solr solr)
 
 # create a new core
-$ docker exec -it --user=solr $SOLR_CONTAINER bin/solr create_core -c gettingstarted
+$ docker exec -it --user=solr $SOLR_CONTAINER solr create_core -c gettingstarted
 
 # check the volume on the host:
 $ ls /home/docker-volumes/mysolr1/solr/
@@ -98,7 +98,7 @@ docker create -v /opt/solr/server/solr --name mysolr1data solr /bin/true
 SOLR_CONTAINER=$(docker run -d -P --volumes-from=mysolr1data solr)
 
 # create a new core
-$ docker exec -it --user=solr $SOLR_CONTAINER bin/solr create_core -c gettingstarted
+$ docker exec -it --user=solr $SOLR_CONTAINER solr create_core -c gettingstarted
 
 # make a change to the config, using the config API
 docker exec -it --user=solr $SOLR_CONTAINER curl http://localhost:8983/solr/gettingstarted/config -H 'Content-type:application/json' -d'{
@@ -198,18 +198,118 @@ Run two Solr nodes, linked to the zookeeper container:
 ```console
 $ docker run --name solr1 --link zookeeper:ZK -d -p 8983:8983 \
       solr \
-      bash -c '/opt/solr/bin/solr start -f -z $ZK_PORT_2181_TCP_ADDR:$ZK_PORT_2181_TCP_PORT'
+      bash -c 'solr start -f -z $ZK_PORT_2181_TCP_ADDR:$ZK_PORT_2181_TCP_PORT'
 
 $ docker run --name solr2 --link zookeeper:ZK -d -p 8984:8983 \
       solr \
-      bash -c '/opt/solr/bin/solr start -f -z $ZK_PORT_2181_TCP_ADDR:$ZK_PORT_2181_TCP_PORT'
+      bash -c 'solr start -f -z $ZK_PORT_2181_TCP_ADDR:$ZK_PORT_2181_TCP_PORT'
 ```
 
 Create a collection:
 
 ```console
-$ docker exec -i -t solr1 /opt/solr/bin/solr create_collection \
-        -c collection1 -shards 2 -p 8983
+$ docker exec -i -t solr1 solr create_collection \
+        -c gettingstarted -shards 2 -p 8983
 ```
 
 Then go to `http://localhost:8983/solr/#/~cloud` (adjust the hostname for your docker host) to see the two shards and Solr nodes.
+
+
+I'm confused about the different invocations of solr -- help?
+-------------------------------------------------------------
+
+The different invocations of the docker-solr image can looks confusing, because the name of the
+image is "solr" and the Solr command is also "solr", and the image interprets various arguments in
+special ways. I'll illustrate the various invocations:
+
+
+To run an arbitrary command in the image:
+
+```
+docker run -it solr date
+```
+
+here "solr" is the name of the image, and "date" is the command.
+This does not invoke any solr functionality.
+
+
+To run the Solr server:
+
+```
+docker run -it solr
+```
+
+Here "solr" is the name of the image, and there is no specific command,
+so the image defaults to run the "solr" command with "-f" to run it in the foreground.
+
+
+To run the Solr server with extra arguments:
+
+```
+docker run -it solr -h myhostname
+```
+
+This is is the same as the previous one, but an additional argument is passed.
+The image will run the "solr" command with "-f -h myhostname"
+
+To run solr as an arbitrary command:
+
+```
+docker run -it solr solr zk --help
+```
+
+here the first "solr" is the image name, and the second "solr"
+is the "solr" command. The image runs the command exactly as specified;
+no "-f" is implicitly added. The container will print help text, and exit.
+
+If you find this visually confusing, it might be helpful to use more specific image tags,
+and specific command paths. For example:
+
+```
+docker run -it solr:6 bin/solr -f -h myhostname
+```
+
+Finally, the docker-solr image offers several commands that do some work before
+then invoking the Solr server, like "solr-precreate" and "solr-demo".
+See the README.md for usage.
+These are implemented by the `docker-entrypoint.sh` script, and must be passed
+as the first argument to the image. For example:
+
+```
+docker run -it solr:6 solr-demo
+```
+
+It's important to understand an implementation detail here. The Dockerfile uses
+`solr-foreground` as the `CMD`, and the `docker-entrypoint.sh` implements
+that by by running "solr -f". So these two are equivalent:
+
+```
+docker run -it solr:6
+docker run -it solr:6 solr-foreground
+```
+
+whereas:
+
+```
+docker run -it solr:6 solr -f
+```
+
+is slightly different: the "solr" there is a generic command, not treated in any
+special way by `docker-entrypoint.sh`. In particular, this means that the
+`docker-entrypoint-initdb.d` mechanism is not applied.
+So, if you want to use `docker-entrypoint-initdb.d`, then you must use one
+of the other two invocations.
+You also need to keep that in mind when you want to invoke solr from the bash
+command. For example, this does NOT run `docker-entrypoint-initdb.d` scripts:
+
+```
+docker run -it -v $PWD/set-heap.sh:/docker-entrypoint-initdb.d/set-heap.sh \
+    solr:6 bash -c "echo hello; solr -f"
+```
+
+but this does:
+
+```
+docker run -it $PWD/set-heap.sh:/docker-entrypoint-initdb.d/set-heap.sh \
+    solr:6 bash -c "echo hello; /opt/docker-solr/scripts/docker-entrypoint.sh solr-foreground"
+```

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -61,4 +61,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -53,4 +53,4 @@ WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr"]
+CMD ["solr-foreground"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Then with a web browser go to `http://localhost:8983/` to see the Admin Console 
 To use Solr, you need to create a "core", an index for your data. For example:
 
 ```console
-$ docker exec -it --user=solr my_solr bin/solr create_core -c gettingstarted
+$ docker exec -it --user=solr my_solr solr create_core -c gettingstarted
 ```
 
 In the web UI if you click on "Core Admin" you should now see the "gettingstarted" core.
@@ -46,7 +46,7 @@ In the web UI if you click on "Core Admin" you should now see the "gettingstarte
 If you want to load some of the example data that is included in the container:
 
 ```console
-$ docker exec -it --user=solr my_solr bin/post -c gettingstarted example/exampledocs/manufacturers.xml
+$ docker exec -it --user=solr my_solr post -c gettingstarted example/exampledocs/manufacturers.xml
 ```
 
 In the UI, find the "Core selector" popup menu and select the "gettingstarted" core, then select the "Query" menu item. This gives you a default search for `*:*` which returns all docs. Hit the "Execute Query" button, and you should see a few docs with data. Congratulations!
@@ -65,15 +65,15 @@ If you want load your own data, you'll have to make it available to the containe
 
 ```console
 $ docker cp $HOME/mydata/mydata.xml my_solr:/opt/solr/mydata.xml
-$ docker exec -it --user=solr my_solr bin/post -c gettingstarted mydata.xml
+$ docker exec -it --user=solr my_solr post -c gettingstarted mydata.xml
 ```
 
 or by using Docker host volumes:
 
 ```console
 $ docker run --name my_solr -d -p 8983:8983 -t -v $HOME/mydata:/opt/solr/mydata solr
-$ docker exec -it --user=solr my_solr bin/solr create_core -c gettingstarted
-$ docker exec -it --user=solr my_solr bin/post -c gettingstarted mydata/mydata.xml
+$ docker exec -it --user=solr my_solr solr create_core -c gettingstarted
+$ docker exec -it --user=solr my_solr post -c gettingstarted mydata/mydata.xml
 ```
 
 To learn more about Solr, see the [Apache Solr Reference Guide](https://cwiki.apache.org/confluence/display/solr/Apache+Solr+Reference+Guide).

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-    set -- solr "$@"
+    set -- solr-foreground "$@"
 fi
 
 if [[ "$VERBOSE" = "yes" ]]; then
@@ -52,7 +52,7 @@ function init_actions {
     done
 }
 
-if [[ "$1" = 'solr' ]]; then
+if [[ "$1" = 'solr-foreground' ]]; then
     init_actions
     shift; set -- solr -f "$@"
 elif [[ "$1" = 'solr-create' ]]; then


### PR DESCRIPTION
Change the default CMD to "solr-foreground", and run solr with '-f' only for that.

For example:

To run an arbitrary command:

    docker run -it solr /bin/date

To run solr in the foreground without arguments:

    docker run -it solr

To run solr in the foreground with extra arguments:

    docker run -it solr -h myhostname

To run solr as an arbitrary command:

    docker run -it solr solr zk --help

Fixes https://github.com/docker-solr/docker-solr/issues/71