### PR TITLE
Convert from "java" (deprecated as of 2016-12-31) to "openjdk"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ services:
 
 before_install:
 - docker info
-- docker pull java:openjdk-8-jre
-- docker pull java:openjdk-8-jre-alpine
+- docker pull openjdk:8-jre
+- docker pull openjdk:8-jre-alpine
 
 script:
 - bash build-all.sh versions build_all test_all push_all

--- a/5.3/Dockerfile
+++ b/5.3/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre
+FROM    openjdk:8-jre
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/5.3/alpine/Dockerfile
+++ b/5.3/alpine/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre-alpine
+FROM    openjdk:8-jre-alpine
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre
+FROM    openjdk:8-jre
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/5.4/alpine/Dockerfile
+++ b/5.4/alpine/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre-alpine
+FROM    openjdk:8-jre-alpine
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre
+FROM    openjdk:8-jre
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/5.5/alpine/Dockerfile
+++ b/5.5/alpine/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre-alpine
+FROM    openjdk:8-jre-alpine
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre
+FROM    openjdk:8-jre
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/6.0/alpine/Dockerfile
+++ b/6.0/alpine/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre-alpine
+FROM    openjdk:8-jre-alpine
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/6.1/Dockerfile
+++ b/6.1/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre
+FROM    openjdk:8-jre
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/6.1/alpine/Dockerfile
+++ b/6.1/alpine/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre-alpine
+FROM    openjdk:8-jre-alpine
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre
+FROM    openjdk:8-jre
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/6.2/alpine/Dockerfile
+++ b/6.2/alpine/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre-alpine
+FROM    openjdk:8-jre-alpine
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/6.3/Dockerfile
+++ b/6.3/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre
+FROM    openjdk:8-jre
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/6.3/alpine/Dockerfile
+++ b/6.3/alpine/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre-alpine
+FROM    openjdk:8-jre-alpine
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre-alpine
+FROM    openjdk:8-jre-alpine
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,5 +1,5 @@
 
-FROM    java:openjdk-8-jre
+FROM    openjdk:8-jre
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:


### PR DESCRIPTION
See https://github.com/docker-library/docs/pull/660/files#diff-5b18106a0a6d9cd97a6ecf2793c3347e (https://hub.docker.com/_/java/).