### PR TITLE
Update set-heap.sh

### DIFF
--- a/docs/set-heap.sh
+++ b/docs/set-heap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-sed -e 's/SOLR_HEAP=".*"/SOLR_HEAP="1024m"/' </opt/solr/bin/solr.in.sh.orig >/opt/solr/bin/solr.in.sh
+sed -e 's/#SOLR_HEAP=".*"/SOLR_HEAP="1024m"/' </opt/solr/bin/solr.in.sh.orig >/opt/solr/bin/solr.in.sh
 grep '^SOLR_HEAP=' /opt/solr/bin/solr.in.sh


### PR DESCRIPTION
Because the SOLR_HEAP= line is commented out in the default /opt/solr/bin/solr.in.sh file the example set-heap.sh doesn't actually apply it to Solr.

On this pull request note the # added before the first SOLR_HEAP on the sed command that uncomments that line and therefore makes it used by solr