### PR TITLE
Fix positional arguments for solr-precreate script

### DIFF
--- a/5.5/alpine/scripts/solr-precreate
+++ b/5.5/alpine/scripts/solr-precreate
@@ -19,8 +19,8 @@ fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-CORE=${2:-gettingstarted}
-CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
 if [[ -z $SOLR_HOME ]]; then
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir

--- a/5.5/scripts/solr-precreate
+++ b/5.5/scripts/solr-precreate
@@ -19,8 +19,8 @@ fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-CORE=${2:-gettingstarted}
-CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
 if [[ -z $SOLR_HOME ]]; then
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir

--- a/6.3/alpine/scripts/solr-precreate
+++ b/6.3/alpine/scripts/solr-precreate
@@ -19,8 +19,8 @@ fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-CORE=${2:-gettingstarted}
-CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
 if [[ -z $SOLR_HOME ]]; then
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir

--- a/6.3/scripts/solr-precreate
+++ b/6.3/scripts/solr-precreate
@@ -19,8 +19,8 @@ fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-CORE=${2:-gettingstarted}
-CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
 if [[ -z $SOLR_HOME ]]; then
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir

--- a/6.4/alpine/scripts/solr-precreate
+++ b/6.4/alpine/scripts/solr-precreate
@@ -19,8 +19,8 @@ fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-CORE=${2:-gettingstarted}
-CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
 if [[ -z $SOLR_HOME ]]; then
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir

--- a/6.4/scripts/solr-precreate
+++ b/6.4/scripts/solr-precreate
@@ -19,8 +19,8 @@ fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-CORE=${2:-gettingstarted}
-CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
 if [[ -z $SOLR_HOME ]]; then
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir

--- a/scripts/solr-precreate
+++ b/scripts/solr-precreate
@@ -19,8 +19,8 @@ fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-CORE=${2:-gettingstarted}
-CONFIG_SOURCE=${3:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
 if [[ -z $SOLR_HOME ]]; then
     coresdir="/opt/solr/server/solr/mycores"
     mkdir -p $coresdir


### PR DESCRIPTION
After being extracted from the docker-entrypoint.sh script, the positional arguments should have been shifted once.