### PR TITLE
Issue107 init solr home error reporting

### DIFF
--- a/5.5/alpine/scripts/init-solr-home
+++ b/5.5/alpine/scripts/init-solr-home
@@ -34,7 +34,7 @@ if [ ! -d "$SOLR_HOME" ]; then
 fi
 
 # check for existing Solr
-if [ -d "$SOLR_HOME/server/solr" ]; then
+if [ -f "$SOLR_HOME/solr.xml" ]; then
    exit
 fi
 

--- a/5.5/alpine/scripts/init-solr-home
+++ b/5.5/alpine/scripts/init-solr-home
@@ -33,9 +33,15 @@ if [ ! -d "$SOLR_HOME" ]; then
     exit 1
 fi
 
-# don't do anything if it is non-empty
+# check for existing Solr
+if [ -d "$SOLR_HOME/server/solr" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
 if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
-    exit
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
 fi
 
 # populate with default solr home contents

--- a/5.5/scripts/init-solr-home
+++ b/5.5/scripts/init-solr-home
@@ -34,7 +34,7 @@ if [ ! -d "$SOLR_HOME" ]; then
 fi
 
 # check for existing Solr
-if [ -d "$SOLR_HOME/server/solr" ]; then
+if [ -f "$SOLR_HOME/solr.xml" ]; then
    exit
 fi
 

--- a/5.5/scripts/init-solr-home
+++ b/5.5/scripts/init-solr-home
@@ -33,9 +33,15 @@ if [ ! -d "$SOLR_HOME" ]; then
     exit 1
 fi
 
-# don't do anything if it is non-empty
+# check for existing Solr
+if [ -d "$SOLR_HOME/server/solr" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
 if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
-    exit
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
 fi
 
 # populate with default solr home contents

--- a/6.3/alpine/scripts/init-solr-home
+++ b/6.3/alpine/scripts/init-solr-home
@@ -34,7 +34,7 @@ if [ ! -d "$SOLR_HOME" ]; then
 fi
 
 # check for existing Solr
-if [ -d "$SOLR_HOME/server/solr" ]; then
+if [ -f "$SOLR_HOME/solr.xml" ]; then
    exit
 fi
 

--- a/6.3/alpine/scripts/init-solr-home
+++ b/6.3/alpine/scripts/init-solr-home
@@ -33,9 +33,15 @@ if [ ! -d "$SOLR_HOME" ]; then
     exit 1
 fi
 
-# don't do anything if it is non-empty
+# check for existing Solr
+if [ -d "$SOLR_HOME/server/solr" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
 if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
-    exit
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
 fi
 
 # populate with default solr home contents

--- a/6.3/scripts/init-solr-home
+++ b/6.3/scripts/init-solr-home
@@ -34,7 +34,7 @@ if [ ! -d "$SOLR_HOME" ]; then
 fi
 
 # check for existing Solr
-if [ -d "$SOLR_HOME/server/solr" ]; then
+if [ -f "$SOLR_HOME/solr.xml" ]; then
    exit
 fi
 

--- a/6.3/scripts/init-solr-home
+++ b/6.3/scripts/init-solr-home
@@ -33,9 +33,15 @@ if [ ! -d "$SOLR_HOME" ]; then
     exit 1
 fi
 
-# don't do anything if it is non-empty
+# check for existing Solr
+if [ -d "$SOLR_HOME/server/solr" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
 if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
-    exit
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
 fi
 
 # populate with default solr home contents

--- a/6.4/alpine/scripts/init-solr-home
+++ b/6.4/alpine/scripts/init-solr-home
@@ -34,7 +34,7 @@ if [ ! -d "$SOLR_HOME" ]; then
 fi
 
 # check for existing Solr
-if [ -d "$SOLR_HOME/server/solr" ]; then
+if [ -f "$SOLR_HOME/solr.xml" ]; then
    exit
 fi
 

--- a/6.4/alpine/scripts/init-solr-home
+++ b/6.4/alpine/scripts/init-solr-home
@@ -33,9 +33,15 @@ if [ ! -d "$SOLR_HOME" ]; then
     exit 1
 fi
 
-# don't do anything if it is non-empty
+# check for existing Solr
+if [ -d "$SOLR_HOME/server/solr" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
 if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
-    exit
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
 fi
 
 # populate with default solr home contents

--- a/6.4/scripts/init-solr-home
+++ b/6.4/scripts/init-solr-home
@@ -34,7 +34,7 @@ if [ ! -d "$SOLR_HOME" ]; then
 fi
 
 # check for existing Solr
-if [ -d "$SOLR_HOME/server/solr" ]; then
+if [ -f "$SOLR_HOME/solr.xml" ]; then
    exit
 fi
 

--- a/6.4/scripts/init-solr-home
+++ b/6.4/scripts/init-solr-home
@@ -33,9 +33,15 @@ if [ ! -d "$SOLR_HOME" ]; then
     exit 1
 fi
 
-# don't do anything if it is non-empty
+# check for existing Solr
+if [ -d "$SOLR_HOME/server/solr" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
 if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
-    exit
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
 fi
 
 # populate with default solr home contents

--- a/scripts/init-solr-home
+++ b/scripts/init-solr-home
@@ -34,7 +34,7 @@ if [ ! -d "$SOLR_HOME" ]; then
 fi
 
 # check for existing Solr
-if [ -d "$SOLR_HOME/server/solr" ]; then
+if [ -f "$SOLR_HOME/solr.xml" ]; then
    exit
 fi
 

--- a/scripts/init-solr-home
+++ b/scripts/init-solr-home
@@ -33,9 +33,15 @@ if [ ! -d "$SOLR_HOME" ]; then
     exit 1
 fi
 
-# don't do anything if it is non-empty
+# check for existing Solr
+if [ -d "$SOLR_HOME/server/solr" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
 if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
-    exit
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
 fi
 
 # populate with default solr home contents


### PR DESCRIPTION
When init-solr-home home is used, check specifically for an existing solr installation (and use that),
and check for a non-empty directory and refuse to initialise that.

Fixes issue #107