### PR TITLE
Switch back to fetching keys from a keyserver, but use multiple keyservers to handle edge cases better

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -16,18 +16,27 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 5.5.4
-
 ENV SOLR_KEY E6E21FFCDCEA14C95910EA65051A0FAF76BC6507
-ENV KEYS https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/KEYS
+RUN echo "fetching GPG key $SOLR_KEY"; \
+  for server in \
+    ha.pool.sks-keyservers.net \
+    hkp://keyserver.ubuntu.com:80 \
+    hkp://p80.pool.sks-keyservers.net:80 \
+    pgp.mit.edu \
+  ; do \
+    echo "  trying $server"; \
+    if gpg --keyserver "$server" --recv-keys "$SOLR_KEY"; then \
+      exit 0; \
+    fi; \
+  done; \
+  echo >&2 "error: failed to fetch $SOLR_KEY from several disparate servers -- network issues?"; \
+  exit 1
 
+ENV SOLR_VERSION 5.5.4
 ENV SOLR_SHA256 c1528e4afc9a0b8e7e5be0a16f40bb4080f410d502cd63b4447d448c49e9f500
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget -nv $KEYS -O /opt/KEYS && \
-  gpg --import /opt/KEYS && \
-  rm /opt/KEYS && \
   wget -nv $SOLR_URL -O /opt/solr.tgz && \
   wget -nv $SOLR_URL.asc -O /opt/solr.tgz.asc && \
   echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \

--- a/5.5/alpine/Dockerfile
+++ b/5.5/alpine/Dockerfile
@@ -21,18 +21,27 @@ ENV SOLR_UID 8983
 RUN addgroup -S -g $SOLR_UID $SOLR_USER && \
   adduser -S -u $SOLR_UID -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 5.5.4
-
 ENV SOLR_KEY E6E21FFCDCEA14C95910EA65051A0FAF76BC6507
-ENV KEYS https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/KEYS
+RUN echo "fetching GPG key $SOLR_KEY"; \
+  for server in \
+    ha.pool.sks-keyservers.net \
+    hkp://keyserver.ubuntu.com:80 \
+    hkp://p80.pool.sks-keyservers.net:80 \
+    pgp.mit.edu \
+  ; do \
+    echo "  trying $server"; \
+    if gpg --keyserver "$server" --recv-keys "$SOLR_KEY"; then \
+      exit 0; \
+    fi; \
+  done; \
+  echo >&2 "error: failed to fetch $SOLR_KEY from several disparate servers -- network issues?"; \
+  exit 1
 
+ENV SOLR_VERSION 5.5.4
 ENV SOLR_SHA256 c1528e4afc9a0b8e7e5be0a16f40bb4080f410d502cd63b4447d448c49e9f500
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget -nv $KEYS -O /opt/KEYS && \
-  gpg --import /opt/KEYS && \
-  rm /opt/KEYS && \
   echo "downloading $SOLR_URL" && \
   wget -q $SOLR_URL -O /opt/solr.tgz && \
   echo "downloading $SOLR_URL.asc" && \

--- a/6.3/Dockerfile
+++ b/6.3/Dockerfile
@@ -16,18 +16,27 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 6.3.0
-
 ENV SOLR_KEY 38D2EA16DDF5FC722EBC433FDC92616F177050F6
-ENV KEYS https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/KEYS
+RUN echo "fetching GPG key $SOLR_KEY"; \
+  for server in \
+    ha.pool.sks-keyservers.net \
+    hkp://keyserver.ubuntu.com:80 \
+    hkp://p80.pool.sks-keyservers.net:80 \
+    pgp.mit.edu \
+  ; do \
+    echo "  trying $server"; \
+    if gpg --keyserver "$server" --recv-keys "$SOLR_KEY"; then \
+      exit 0; \
+    fi; \
+  done; \
+  echo >&2 "error: failed to fetch $SOLR_KEY from several disparate servers -- network issues?"; \
+  exit 1
 
+ENV SOLR_VERSION 6.3.0
 ENV SOLR_SHA256 07692257575fe54ddb8a8f64e96d3d352f2f533aa91b5752be1869d2acf2f544
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget -nv $KEYS -O /opt/KEYS && \
-  gpg --import /opt/KEYS && \
-  rm /opt/KEYS && \
   wget -nv $SOLR_URL -O /opt/solr.tgz && \
   wget -nv $SOLR_URL.asc -O /opt/solr.tgz.asc && \
   echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \

--- a/6.3/alpine/Dockerfile
+++ b/6.3/alpine/Dockerfile
@@ -21,18 +21,27 @@ ENV SOLR_UID 8983
 RUN addgroup -S -g $SOLR_UID $SOLR_USER && \
   adduser -S -u $SOLR_UID -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 6.3.0
-
 ENV SOLR_KEY 38D2EA16DDF5FC722EBC433FDC92616F177050F6
-ENV KEYS https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/KEYS
+RUN echo "fetching GPG key $SOLR_KEY"; \
+  for server in \
+    ha.pool.sks-keyservers.net \
+    hkp://keyserver.ubuntu.com:80 \
+    hkp://p80.pool.sks-keyservers.net:80 \
+    pgp.mit.edu \
+  ; do \
+    echo "  trying $server"; \
+    if gpg --keyserver "$server" --recv-keys "$SOLR_KEY"; then \
+      exit 0; \
+    fi; \
+  done; \
+  echo >&2 "error: failed to fetch $SOLR_KEY from several disparate servers -- network issues?"; \
+  exit 1
 
+ENV SOLR_VERSION 6.3.0
 ENV SOLR_SHA256 07692257575fe54ddb8a8f64e96d3d352f2f533aa91b5752be1869d2acf2f544
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget -nv $KEYS -O /opt/KEYS && \
-  gpg --import /opt/KEYS && \
-  rm /opt/KEYS && \
   echo "downloading $SOLR_URL" && \
   wget -q $SOLR_URL -O /opt/solr.tgz && \
   echo "downloading $SOLR_URL.asc" && \

--- a/6.4/Dockerfile
+++ b/6.4/Dockerfile
@@ -16,18 +16,27 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 6.4.2
-
 ENV SOLR_KEY 2085660D9C1FCCACC4A479A3BF160FF14992A24C
-ENV KEYS https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/KEYS
+RUN echo "fetching GPG key $SOLR_KEY"; \
+  for server in \
+    ha.pool.sks-keyservers.net \
+    hkp://keyserver.ubuntu.com:80 \
+    hkp://p80.pool.sks-keyservers.net:80 \
+    pgp.mit.edu \
+  ; do \
+    echo "  trying $server"; \
+    if gpg --keyserver "$server" --recv-keys "$SOLR_KEY"; then \
+      exit 0; \
+    fi; \
+  done; \
+  echo >&2 "error: failed to fetch $SOLR_KEY from several disparate servers -- network issues?"; \
+  exit 1
 
+ENV SOLR_VERSION 6.4.2
 ENV SOLR_SHA256 354e1affd9cad7d6e86cde8c03aaeb604876f0764129621d8e231cdb35b31c55
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget -nv $KEYS -O /opt/KEYS && \
-  gpg --import /opt/KEYS && \
-  rm /opt/KEYS && \
   wget -nv $SOLR_URL -O /opt/solr.tgz && \
   wget -nv $SOLR_URL.asc -O /opt/solr.tgz.asc && \
   echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \

--- a/6.4/alpine/Dockerfile
+++ b/6.4/alpine/Dockerfile
@@ -21,18 +21,27 @@ ENV SOLR_UID 8983
 RUN addgroup -S -g $SOLR_UID $SOLR_USER && \
   adduser -S -u $SOLR_UID -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 6.4.2
-
 ENV SOLR_KEY 2085660D9C1FCCACC4A479A3BF160FF14992A24C
-ENV KEYS https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/KEYS
+RUN echo "fetching GPG key $SOLR_KEY"; \
+  for server in \
+    ha.pool.sks-keyservers.net \
+    hkp://keyserver.ubuntu.com:80 \
+    hkp://p80.pool.sks-keyservers.net:80 \
+    pgp.mit.edu \
+  ; do \
+    echo "  trying $server"; \
+    if gpg --keyserver "$server" --recv-keys "$SOLR_KEY"; then \
+      exit 0; \
+    fi; \
+  done; \
+  echo >&2 "error: failed to fetch $SOLR_KEY from several disparate servers -- network issues?"; \
+  exit 1
 
+ENV SOLR_VERSION 6.4.2
 ENV SOLR_SHA256 354e1affd9cad7d6e86cde8c03aaeb604876f0764129621d8e231cdb35b31c55
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget -nv $KEYS -O /opt/KEYS && \
-  gpg --import /opt/KEYS && \
-  rm /opt/KEYS && \
   echo "downloading $SOLR_URL" && \
   wget -q $SOLR_URL -O /opt/solr.tgz && \
   echo "downloading $SOLR_URL.asc" && \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -21,18 +21,27 @@ ENV SOLR_UID 8983
 RUN addgroup -S -g $SOLR_UID $SOLR_USER && \
   adduser -S -u $SOLR_UID -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 0.0.0
-
 ENV SOLR_KEY "fingerprint-goes-here"
-ENV KEYS https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/KEYS
+RUN echo "fetching GPG key $SOLR_KEY"; \
+  for server in \
+    ha.pool.sks-keyservers.net \
+    hkp://keyserver.ubuntu.com:80 \
+    hkp://p80.pool.sks-keyservers.net:80 \
+    pgp.mit.edu \
+  ; do \
+    echo "  trying $server"; \
+    if gpg --keyserver "$server" --recv-keys "$SOLR_KEY"; then \
+      exit 0; \
+    fi; \
+  done; \
+  echo >&2 "error: failed to fetch $SOLR_KEY from several disparate servers -- network issues?"; \
+  exit 1
 
+ENV SOLR_VERSION 0.0.0
 ENV SOLR_SHA256 "checksum-goes-here"
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget -nv $KEYS -O /opt/KEYS && \
-  gpg --import /opt/KEYS && \
-  rm /opt/KEYS && \
   echo "downloading $SOLR_URL" && \
   wget -q $SOLR_URL -O /opt/solr.tgz && \
   echo "downloading $SOLR_URL.asc" && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -16,18 +16,27 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 0.0.0
-
 ENV SOLR_KEY "fingerprint-goes-here"
-ENV KEYS https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/KEYS
+RUN echo "fetching GPG key $SOLR_KEY"; \
+  for server in \
+    ha.pool.sks-keyservers.net \
+    hkp://keyserver.ubuntu.com:80 \
+    hkp://p80.pool.sks-keyservers.net:80 \
+    pgp.mit.edu \
+  ; do \
+    echo "  trying $server"; \
+    if gpg --keyserver "$server" --recv-keys "$SOLR_KEY"; then \
+      exit 0; \
+    fi; \
+  done; \
+  echo >&2 "error: failed to fetch $SOLR_KEY from several disparate servers -- network issues?"; \
+  exit 1
 
+ENV SOLR_VERSION 0.0.0
 ENV SOLR_SHA256 "checksum-goes-here"
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
 
 RUN mkdir -p /opt/solr && \
-  wget -nv $KEYS -O /opt/KEYS && \
-  gpg --import /opt/KEYS && \
-  rm /opt/KEYS && \
   wget -nv $SOLR_URL -O /opt/solr.tgz && \
   wget -nv $SOLR_URL.asc -O /opt/solr.tgz.asc && \
   echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \


### PR DESCRIPTION
Also, this modifies `update.sh` to ensure that several keyservers definitely have a copy of the public key we need.

This should account for flakiness in ha.pool.sks-keyservers.net, as well as flakiness in environments where the default HKP port is blocked (by explicitly trying to use other keyservers that listen on port 80).

This reverts some of https://github.com/docker-solr/docker-solr/pull/109 (be05c8c5748e588d38cb0ed96770cf7ba9956589), in reference to https://github.com/docker-solr/docker-solr/issues/106#issuecomment-285137497.

cc @yosifkit

ref https://github.com/docker-library/official-images/pull/2729