### PR TITLE
Update generate-stackbrew-library.sh for multiple architecures

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 ARG SOLR_DOWNLOAD_SERVER
 
 RUN apt-get update && \
-  apt-get -y install lsof procps && \
+  apt-get -y install lsof procps wget gpg && \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER solr

--- a/5.5/slim/Dockerfile
+++ b/5.5/slim/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    openjdk:8-jre
+FROM    openjdk:8-jre-slim
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:
@@ -16,10 +16,10 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -G $SOLR_USER -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION version-goes-here
+ENV SOLR_VERSION 5.5.4
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
-ENV SOLR_SHA256 checksum-goes-here
-ENV SOLR_KEYS fingerprint-goes-here
+ENV SOLR_SHA256 c1528e4afc9a0b8e7e5be0a16f40bb4080f410d502cd63b4447d448c49e9f500
+ENV SOLR_KEYS E6E21FFCDCEA14C95910EA65051A0FAF76BC6507
 
 RUN set -e; for key in $SOLR_KEYS; do \
     found=''; \

--- a/5.5/slim/scripts/docker-entrypoint.sh
+++ b/5.5/slim/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/5.5/slim/scripts/init-solr-home
+++ b/5.5/slim/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/5.5/slim/scripts/run-initdb
+++ b/5.5/slim/scripts/run-initdb
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    fpath="/docker-entrypoint-initdb.d/$f"
+    case "$f" in
+        *.sh)     echo "$0: running $fpath"; . "$fpath" ;;
+        *)        echo "$0: ignoring $fpath" ;;
+    esac
+    echo
+done < <(ls /docker-entrypoint-initdb.d/ | sort -n)

--- a/5.5/slim/scripts/solr-create
+++ b/5.5/slim/scripts/solr-create
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
+
+set -e
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/core_created
+if [ -f $sentinel ]; then
+    echo "skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with: ${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with: ${@:1}"
+    stop-local-solr
+    touch $sentinel
+fi
+exec solr -f

--- a/5.5/slim/scripts/solr-demo
+++ b/5.5/slim/scripts/solr-demo
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/demo_created
+if [ -f $sentinel ]; then
+  echo "skipping demo creation"
+else
+  CORE=demo
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+  touch $sentinel
+fi
+
+exec solr -f

--- a/5.5/slim/scripts/solr-foreground
+++ b/5.5/slim/scripts/solr-foreground
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+exec solr -f "$@"

--- a/5.5/slim/scripts/solr-precreate
+++ b/5.5/slim/scripts/solr-precreate
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r $CONFIG_SOURCE/ $coredir
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi
+exec solr -f

--- a/5.5/slim/scripts/start-local-solr
+++ b/5.5/slim/scripts/start-local-solr
@@ -1,0 +1,25 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Configuring Solr to bind to 127.0.0.1"
+cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
+echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+
+echo "Running solr in the background. Logs are in /opt/solr/server/logs"
+solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f /opt/solr/server/logs/solr.log ]; then
+        echo "Here is the log:"
+        cat /opt/solr/server/logs/solr.log
+    fi
+    exit 1
+fi

--- a/5.5/slim/scripts/stop-local-solr
+++ b/5.5/slim/scripts/stop-local-solr
@@ -1,0 +1,14 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop
+
+echo "Restoring Solr configuration"
+mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/5.5/slim/scripts/wait-for-solr.sh
+++ b/5.5/slim/scripts/wait-for-solr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [ max_try [ wait_seconds ] ]
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo $@
+  echo "$0 [ max_try [ wait_seconds ] ]"
+  exit 1
+}
+
+max_try=$1
+if [[ -z $max_try ]]; then
+  max_try=12
+else
+  grep -q -E '^[0-9]+$' <<<$max_try || usage "$max_try is not a number"
+fi
+wait_seconds=$2
+if [[ -z $wait_seconds ]]; then
+  wait_seconds=5
+else
+  grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "$wait_seconds is not a number"
+fi
+let i=1
+until wget -q -O - http://localhost:8983 | grep -q -i solr; do
+  echo "solr is not running yet"
+  if (( $i == $max_try )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  let "i++"
+  sleep $wait_seconds
+done
+echo "solr is running"

--- a/6.3/Dockerfile
+++ b/6.3/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 ARG SOLR_DOWNLOAD_SERVER
 
 RUN apt-get update && \
-  apt-get -y install lsof procps && \
+  apt-get -y install lsof procps wget gpg && \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER solr

--- a/6.3/slim/Dockerfile
+++ b/6.3/slim/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    openjdk:8-jre
+FROM    openjdk:8-jre-slim
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:
@@ -16,10 +16,10 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -G $SOLR_USER -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION version-goes-here
+ENV SOLR_VERSION 6.3.0
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
-ENV SOLR_SHA256 checksum-goes-here
-ENV SOLR_KEYS fingerprint-goes-here
+ENV SOLR_SHA256 07692257575fe54ddb8a8f64e96d3d352f2f533aa91b5752be1869d2acf2f544
+ENV SOLR_KEYS 38D2EA16DDF5FC722EBC433FDC92616F177050F6
 
 RUN set -e; for key in $SOLR_KEYS; do \
     found=''; \

--- a/6.3/slim/scripts/docker-entrypoint.sh
+++ b/6.3/slim/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/6.3/slim/scripts/init-solr-home
+++ b/6.3/slim/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/6.3/slim/scripts/run-initdb
+++ b/6.3/slim/scripts/run-initdb
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    fpath="/docker-entrypoint-initdb.d/$f"
+    case "$f" in
+        *.sh)     echo "$0: running $fpath"; . "$fpath" ;;
+        *)        echo "$0: ignoring $fpath" ;;
+    esac
+    echo
+done < <(ls /docker-entrypoint-initdb.d/ | sort -n)

--- a/6.3/slim/scripts/solr-create
+++ b/6.3/slim/scripts/solr-create
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
+
+set -e
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/core_created
+if [ -f $sentinel ]; then
+    echo "skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with: ${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with: ${@:1}"
+    stop-local-solr
+    touch $sentinel
+fi
+exec solr -f

--- a/6.3/slim/scripts/solr-demo
+++ b/6.3/slim/scripts/solr-demo
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/demo_created
+if [ -f $sentinel ]; then
+  echo "skipping demo creation"
+else
+  CORE=demo
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+  touch $sentinel
+fi
+
+exec solr -f

--- a/6.3/slim/scripts/solr-foreground
+++ b/6.3/slim/scripts/solr-foreground
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+exec solr -f "$@"

--- a/6.3/slim/scripts/solr-precreate
+++ b/6.3/slim/scripts/solr-precreate
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r $CONFIG_SOURCE/ $coredir
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi
+exec solr -f

--- a/6.3/slim/scripts/start-local-solr
+++ b/6.3/slim/scripts/start-local-solr
@@ -1,0 +1,25 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Configuring Solr to bind to 127.0.0.1"
+cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
+echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+
+echo "Running solr in the background. Logs are in /opt/solr/server/logs"
+solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f /opt/solr/server/logs/solr.log ]; then
+        echo "Here is the log:"
+        cat /opt/solr/server/logs/solr.log
+    fi
+    exit 1
+fi

--- a/6.3/slim/scripts/stop-local-solr
+++ b/6.3/slim/scripts/stop-local-solr
@@ -1,0 +1,14 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop
+
+echo "Restoring Solr configuration"
+mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.3/slim/scripts/wait-for-solr.sh
+++ b/6.3/slim/scripts/wait-for-solr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [ max_try [ wait_seconds ] ]
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo $@
+  echo "$0 [ max_try [ wait_seconds ] ]"
+  exit 1
+}
+
+max_try=$1
+if [[ -z $max_try ]]; then
+  max_try=12
+else
+  grep -q -E '^[0-9]+$' <<<$max_try || usage "$max_try is not a number"
+fi
+wait_seconds=$2
+if [[ -z $wait_seconds ]]; then
+  wait_seconds=5
+else
+  grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "$wait_seconds is not a number"
+fi
+let i=1
+until wget -q -O - http://localhost:8983 | grep -q -i solr; do
+  echo "solr is not running yet"
+  if (( $i == $max_try )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  let "i++"
+  sleep $wait_seconds
+done
+echo "solr is running"

--- a/6.4/Dockerfile
+++ b/6.4/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 ARG SOLR_DOWNLOAD_SERVER
 
 RUN apt-get update && \
-  apt-get -y install lsof procps && \
+  apt-get -y install lsof procps wget gpg && \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER solr

--- a/6.4/slim/Dockerfile
+++ b/6.4/slim/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    openjdk:8-jre
+FROM    openjdk:8-jre-slim
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:
@@ -16,10 +16,10 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -G $SOLR_USER -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION version-goes-here
+ENV SOLR_VERSION 6.4.2
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
-ENV SOLR_SHA256 checksum-goes-here
-ENV SOLR_KEYS fingerprint-goes-here
+ENV SOLR_SHA256 354e1affd9cad7d6e86cde8c03aaeb604876f0764129621d8e231cdb35b31c55
+ENV SOLR_KEYS 2085660D9C1FCCACC4A479A3BF160FF14992A24C
 
 RUN set -e; for key in $SOLR_KEYS; do \
     found=''; \

--- a/6.4/slim/scripts/docker-entrypoint.sh
+++ b/6.4/slim/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/6.4/slim/scripts/init-solr-home
+++ b/6.4/slim/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/6.4/slim/scripts/run-initdb
+++ b/6.4/slim/scripts/run-initdb
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    fpath="/docker-entrypoint-initdb.d/$f"
+    case "$f" in
+        *.sh)     echo "$0: running $fpath"; . "$fpath" ;;
+        *)        echo "$0: ignoring $fpath" ;;
+    esac
+    echo
+done < <(ls /docker-entrypoint-initdb.d/ | sort -n)

--- a/6.4/slim/scripts/solr-create
+++ b/6.4/slim/scripts/solr-create
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
+
+set -e
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/core_created
+if [ -f $sentinel ]; then
+    echo "skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with: ${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with: ${@:1}"
+    stop-local-solr
+    touch $sentinel
+fi
+exec solr -f

--- a/6.4/slim/scripts/solr-demo
+++ b/6.4/slim/scripts/solr-demo
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/demo_created
+if [ -f $sentinel ]; then
+  echo "skipping demo creation"
+else
+  CORE=demo
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+  touch $sentinel
+fi
+
+exec solr -f

--- a/6.4/slim/scripts/solr-foreground
+++ b/6.4/slim/scripts/solr-foreground
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+exec solr -f "$@"

--- a/6.4/slim/scripts/solr-precreate
+++ b/6.4/slim/scripts/solr-precreate
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r $CONFIG_SOURCE/ $coredir
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi
+exec solr -f

--- a/6.4/slim/scripts/start-local-solr
+++ b/6.4/slim/scripts/start-local-solr
@@ -1,0 +1,25 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Configuring Solr to bind to 127.0.0.1"
+cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
+echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+
+echo "Running solr in the background. Logs are in /opt/solr/server/logs"
+solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f /opt/solr/server/logs/solr.log ]; then
+        echo "Here is the log:"
+        cat /opt/solr/server/logs/solr.log
+    fi
+    exit 1
+fi

--- a/6.4/slim/scripts/stop-local-solr
+++ b/6.4/slim/scripts/stop-local-solr
@@ -1,0 +1,14 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop
+
+echo "Restoring Solr configuration"
+mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.4/slim/scripts/wait-for-solr.sh
+++ b/6.4/slim/scripts/wait-for-solr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [ max_try [ wait_seconds ] ]
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo $@
+  echo "$0 [ max_try [ wait_seconds ] ]"
+  exit 1
+}
+
+max_try=$1
+if [[ -z $max_try ]]; then
+  max_try=12
+else
+  grep -q -E '^[0-9]+$' <<<$max_try || usage "$max_try is not a number"
+fi
+wait_seconds=$2
+if [[ -z $wait_seconds ]]; then
+  wait_seconds=5
+else
+  grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "$wait_seconds is not a number"
+fi
+let i=1
+until wget -q -O - http://localhost:8983 | grep -q -i solr; do
+  echo "solr is not running yet"
+  if (( $i == $max_try )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  let "i++"
+  sleep $wait_seconds
+done
+echo "solr is running"

--- a/6.5/Dockerfile
+++ b/6.5/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 ARG SOLR_DOWNLOAD_SERVER
 
 RUN apt-get update && \
-  apt-get -y install lsof procps && \
+  apt-get -y install lsof procps wget gpg && \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER solr

--- a/6.5/slim/Dockerfile
+++ b/6.5/slim/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    openjdk:8-jre
+FROM    openjdk:8-jre-slim
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:
@@ -16,10 +16,10 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -G $SOLR_USER -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION version-goes-here
+ENV SOLR_VERSION 6.5.1
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
-ENV SOLR_SHA256 checksum-goes-here
-ENV SOLR_KEYS fingerprint-goes-here
+ENV SOLR_SHA256 7c6a7d4474d5e847a8ddd0a4717d33bf5db07adf17c3d36ad1532c72885bd5d3
+ENV SOLR_KEYS 052C5B48A480B9CEA9E218A5F98C13CFA5A135D8
 
 RUN set -e; for key in $SOLR_KEYS; do \
     found=''; \

--- a/6.5/slim/scripts/docker-entrypoint.sh
+++ b/6.5/slim/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/6.5/slim/scripts/init-solr-home
+++ b/6.5/slim/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/6.5/slim/scripts/run-initdb
+++ b/6.5/slim/scripts/run-initdb
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    fpath="/docker-entrypoint-initdb.d/$f"
+    case "$f" in
+        *.sh)     echo "$0: running $fpath"; . "$fpath" ;;
+        *)        echo "$0: ignoring $fpath" ;;
+    esac
+    echo
+done < <(ls /docker-entrypoint-initdb.d/ | sort -n)

--- a/6.5/slim/scripts/solr-create
+++ b/6.5/slim/scripts/solr-create
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
+
+set -e
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/core_created
+if [ -f $sentinel ]; then
+    echo "skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with: ${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with: ${@:1}"
+    stop-local-solr
+    touch $sentinel
+fi
+exec solr -f

--- a/6.5/slim/scripts/solr-demo
+++ b/6.5/slim/scripts/solr-demo
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/demo_created
+if [ -f $sentinel ]; then
+  echo "skipping demo creation"
+else
+  CORE=demo
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+  touch $sentinel
+fi
+
+exec solr -f

--- a/6.5/slim/scripts/solr-foreground
+++ b/6.5/slim/scripts/solr-foreground
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+exec solr -f "$@"

--- a/6.5/slim/scripts/solr-precreate
+++ b/6.5/slim/scripts/solr-precreate
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r $CONFIG_SOURCE/ $coredir
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi
+exec solr -f

--- a/6.5/slim/scripts/start-local-solr
+++ b/6.5/slim/scripts/start-local-solr
@@ -1,0 +1,25 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Configuring Solr to bind to 127.0.0.1"
+cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
+echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+
+echo "Running solr in the background. Logs are in /opt/solr/server/logs"
+solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f /opt/solr/server/logs/solr.log ]; then
+        echo "Here is the log:"
+        cat /opt/solr/server/logs/solr.log
+    fi
+    exit 1
+fi

--- a/6.5/slim/scripts/stop-local-solr
+++ b/6.5/slim/scripts/stop-local-solr
@@ -1,0 +1,14 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop
+
+echo "Restoring Solr configuration"
+mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.5/slim/scripts/wait-for-solr.sh
+++ b/6.5/slim/scripts/wait-for-solr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [ max_try [ wait_seconds ] ]
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo $@
+  echo "$0 [ max_try [ wait_seconds ] ]"
+  exit 1
+}
+
+max_try=$1
+if [[ -z $max_try ]]; then
+  max_try=12
+else
+  grep -q -E '^[0-9]+$' <<<$max_try || usage "$max_try is not a number"
+fi
+wait_seconds=$2
+if [[ -z $wait_seconds ]]; then
+  wait_seconds=5
+else
+  grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "$wait_seconds is not a number"
+fi
+let i=1
+until wget -q -O - http://localhost:8983 | grep -q -i solr; do
+  echo "solr is not running yet"
+  if (( $i == $max_try )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  let "i++"
+  sleep $wait_seconds
+done
+echo "solr is running"

--- a/6.6/Dockerfile
+++ b/6.6/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 ARG SOLR_DOWNLOAD_SERVER
 
 RUN apt-get update && \
-  apt-get -y install lsof procps && \
+  apt-get -y install lsof procps wget gpg && \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER solr

--- a/6.6/slim/Dockerfile
+++ b/6.6/slim/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    openjdk:8-jre
+FROM    openjdk:8-jre-slim
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:
@@ -16,10 +16,10 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -G $SOLR_USER -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION version-goes-here
+ENV SOLR_VERSION 6.6.0
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
-ENV SOLR_SHA256 checksum-goes-here
-ENV SOLR_KEYS fingerprint-goes-here
+ENV SOLR_SHA256 6b1d1ed0b74aef320633b40a38a790477e00d75b56b9cdc578533235315ffa1e
+ENV SOLR_KEYS 2085660D9C1FCCACC4A479A3BF160FF14992A24C
 
 RUN set -e; for key in $SOLR_KEYS; do \
     found=''; \

--- a/6.6/slim/scripts/docker-entrypoint.sh
+++ b/6.6/slim/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/6.6/slim/scripts/init-solr-home
+++ b/6.6/slim/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/6.6/slim/scripts/run-initdb
+++ b/6.6/slim/scripts/run-initdb
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    fpath="/docker-entrypoint-initdb.d/$f"
+    case "$f" in
+        *.sh)     echo "$0: running $fpath"; . "$fpath" ;;
+        *)        echo "$0: ignoring $fpath" ;;
+    esac
+    echo
+done < <(ls /docker-entrypoint-initdb.d/ | sort -n)

--- a/6.6/slim/scripts/solr-create
+++ b/6.6/slim/scripts/solr-create
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
+
+set -e
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/core_created
+if [ -f $sentinel ]; then
+    echo "skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with: ${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with: ${@:1}"
+    stop-local-solr
+    touch $sentinel
+fi
+exec solr -f

--- a/6.6/slim/scripts/solr-demo
+++ b/6.6/slim/scripts/solr-demo
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/demo_created
+if [ -f $sentinel ]; then
+  echo "skipping demo creation"
+else
+  CORE=demo
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+  touch $sentinel
+fi
+
+exec solr -f

--- a/6.6/slim/scripts/solr-foreground
+++ b/6.6/slim/scripts/solr-foreground
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+exec solr -f "$@"

--- a/6.6/slim/scripts/solr-precreate
+++ b/6.6/slim/scripts/solr-precreate
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r $CONFIG_SOURCE/ $coredir
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi
+exec solr -f

--- a/6.6/slim/scripts/start-local-solr
+++ b/6.6/slim/scripts/start-local-solr
@@ -1,0 +1,25 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Configuring Solr to bind to 127.0.0.1"
+cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
+echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+
+echo "Running solr in the background. Logs are in /opt/solr/server/logs"
+solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f /opt/solr/server/logs/solr.log ]; then
+        echo "Here is the log:"
+        cat /opt/solr/server/logs/solr.log
+    fi
+    exit 1
+fi

--- a/6.6/slim/scripts/stop-local-solr
+++ b/6.6/slim/scripts/stop-local-solr
@@ -1,0 +1,14 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop
+
+echo "Restoring Solr configuration"
+mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.6/slim/scripts/wait-for-solr.sh
+++ b/6.6/slim/scripts/wait-for-solr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [ max_try [ wait_seconds ] ]
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo $@
+  echo "$0 [ max_try [ wait_seconds ] ]"
+  exit 1
+}
+
+max_try=$1
+if [[ -z $max_try ]]; then
+  max_try=12
+else
+  grep -q -E '^[0-9]+$' <<<$max_try || usage "$max_try is not a number"
+fi
+wait_seconds=$2
+if [[ -z $wait_seconds ]]; then
+  wait_seconds=5
+else
+  grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "$wait_seconds is not a number"
+fi
+let i=1
+until wget -q -O - http://localhost:8983 | grep -q -i solr; do
+  echo "solr is not running yet"
+  if (( $i == $max_try )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  let "i++"
+  sleep $wait_seconds
+done
+echo "solr is running"

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -1,5 +1,5 @@
 
-FROM    openjdk:8-jre
+FROM    openjdk:8-jre-slim
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:

--- a/build-all.sh
+++ b/build-all.sh
@@ -17,7 +17,7 @@ TAG_LOCAL_BASE=docker-solr/docker-solr
 # The hub user is "dockersolrbuilder".
 TAG_PUSH_BASE=dockersolr/docker-solr
 
-VARIANTS="alpine"
+VARIANTS=(alpine slim)
 
 versions=()
 latest=''
@@ -45,7 +45,7 @@ function get_versions {
     dir_for_version["$full_version"]=$build_dir
     tags_for_version["$full_version"]="${tags[@]}"
 
-    for variant in $VARIANTS; do
+    for variant in ${VARIANTS[@]}; do
       build_dir="./$x_y_dir/$variant"
       full_version="$(grep 'ENV SOLR_VERSION' $build_dir/Dockerfile|awk '{print $3}')"
       min_version=$(echo $full_version | sed -e 's/\..*//')

--- a/build-all.sh
+++ b/build-all.sh
@@ -60,7 +60,7 @@ function get_versions {
     full_version="${min_versions[$v]}"
     tags_for_version["$full_version"]="${tags_for_version["$full_version"]} $v"
   done
-  tags_for_version["$latest"]="${tags_for_version["$full_version"]} latest"
+  tags_for_version["$latest"]="${tags_for_version["$latest"]} latest"
 }
 
 function print_versions {

--- a/build-all.sh
+++ b/build-all.sh
@@ -3,9 +3,9 @@
 # Script to rebuild Solr images in this repository locally, and test them.
 # This should probably be replaced with some bashbrew.
 
-set -e
+set -euo pipefail
 
-if [[ ! -z $DEBUG ]]; then
+if [[ ! -z "${DEBUG:-}" ]]; then
   set -x
 fi
 
@@ -29,31 +29,33 @@ declare -A tags_for_version
 # map minimum version to the full_version
 declare -A min_versions
 
+function join_by { local IFS="$1"; shift; echo "$*"; }
+
 function get_versions {
-  x_y_dirs=$(ls | grep -E '^[0-9]+\.[0-9]+$' | sort --version-sort)
+  x_y_dirs=$(find . -maxdepth 1 -print | sed 's,^\./,,' | grep -E '^[0-9]+\.[0-9]+$' | sort --version-sort)
   latest_dir=$(echo "$x_y_dirs" | tail -n 1)
   for x_y_dir in $x_y_dirs; do
     build_dir="./$x_y_dir"
-    full_version="$(grep 'ENV SOLR_VERSION' $build_dir/Dockerfile|awk '{print $3}')"
+    full_version="$(grep 'ENV SOLR_VERSION' "$build_dir/Dockerfile" | awk '{print $3}')"
     versions+=($full_version)
-    min_version=$(echo $full_version | sed -e 's/\..*//')
+    min_version=$(sed -e 's/\..*//' <<<$full_version)
     min_versions["$min_version"]=$full_version
-    tags=($full_version $x_y_dir)
-    if [[ $x_y_dir = $latest_dir ]]; then
+    tags="$full_version $x_y_dir"
+    if [[ $x_y_dir = "$latest_dir" ]]; then
       latest=$full_version
     fi
     dir_for_version["$full_version"]=$build_dir
-    tags_for_version["$full_version"]="${tags[@]}"
+    tags_for_version["$full_version"]=$tags
 
-    for variant in ${VARIANTS[@]}; do
+    for variant in "${VARIANTS[@]}"; do
       build_dir="./$x_y_dir/$variant"
-      full_version="$(grep 'ENV SOLR_VERSION' $build_dir/Dockerfile|awk '{print $3}')"
-      min_version=$(echo $full_version | sed -e 's/\..*//')
+      full_version="$(grep 'ENV SOLR_VERSION' "$build_dir/Dockerfile" | awk '{print $3}')"
+      min_version=$(sed -e 's/\..*//' <<<$full_version)
       min_versions["$min_version-$variant"]="$full_version-$variant"
       versions+=("$full_version-$variant")
-      tags=("$full_version-$variant" "$x_y_dir-$variant")
+      tags="$full_version-$variant $x_y_dir-$variant"
       dir_for_version["$full_version-$variant"]=$build_dir
-      tags_for_version["$full_version-$variant"]="${tags[@]}"
+      tags_for_version["$full_version-$variant"]=$tags
     done
   done
   for v in "${!min_versions[@]}"; do
@@ -65,7 +67,7 @@ function get_versions {
 
 function print_versions {
   echo "versions found:"
-  for full_version in ${versions[@]}; do
+  for full_version in "${versions[@]}"; do
     echo "  full_version=$full_version build_dir=${dir_for_version[$full_version]} tags: ${tags_for_version[$full_version]}"
   done
 }
@@ -73,13 +75,12 @@ function print_versions {
 function build {
   local full_version=$1
   local build_dir=$2
-  shift 2
-  local tags=$@
+  local tags=$3
   tag="$TAG_LOCAL_BASE:$full_version"
   # write a build script in the directory, so you can go there and invoke manually for debugging
   # Travis is still on Docker 1.9 at the moment, so do only a single tag during the build,
   # and apply the other tags after.
-  cat > $build_dir/build.sh <<EOM
+  cat > "$build_dir/build.sh" <<EOM
 #!/bin/bash
 set -e
 if [ ! -z "\$SOLR_DOWNLOAD_SERVER" ]; then
@@ -97,20 +98,20 @@ for t in $tags; do
   \$cmd
 done
 EOM
-  chmod u+x $build_dir/build.sh
-  (cd $build_dir; ./build.sh)
+  chmod u+x "$build_dir/build.sh"
+  (cd "$build_dir"; ./build.sh)
   echo
 }
 
 function container_cleanup {
   local container_name=$1
-  previous=$(docker ps --filter name=$container_name --format '{{.ID}}' --no-trunc)
+  previous=$(docker ps --filter name="$container_name" --format '{{.ID}}' --no-trunc)
   if [[ ! -z $previous ]]; then
     echo "killing $container_name"
-    docker kill $container_name || true
+    docker kill "$container_name" || true
     sleep 2
     echo "removing $container_name"
-    docker rm $container_name || true
+    docker rm "$container_name" || true
   fi
 }
 
@@ -119,41 +120,41 @@ function container_cleanup {
 function test_simple {
   local tag=$1
   echo "Test $tag"
-  container_name='test_'$(echo $tag|tr ':/-' '_')
+  container_name='test_'$(echo "$tag" | tr ':/-' '_')
   echo "Cleaning up left-over containers from previous runs"
-  container_cleanup $container_name
+  container_cleanup "$container_name"
   echo "Running $container_name"
-  docker run --name $container_name -d $tag
+  docker run --name "$container_name" -d "$tag"
   SLEEP_SECS=5
   echo "Sleeping $SLEEP_SECS seconds..."
   sleep $SLEEP_SECS
-  container_status=$(docker inspect --format='{{.State.Status}}' $container_name)
+  container_status=$(docker inspect --format='{{.State.Status}}' "$container_name")
   echo "container $container_name status: $container_status"
   if [[ $container_status == 'exited' ]]; then
-    docker logs $container_name
+    docker logs "$container_name"
     exit 1
   fi
   echo "Checking that the OS matches the tag '$tag'"
   if echo "$tag" | grep -q -- -alpine; then
-    alpine_version=$(docker exec --user=solr $container_name cat /etc/alpine-release || true)
+    alpine_version=$(docker exec --user=solr "$container_name" cat /etc/alpine-release || true)
     if [[ -z $alpine_version ]]; then
       echo "Could not get alpine version from container $container_name"
-      container_cleanup $container_name
+      container_cleanup "$container_name"
       exit 1
     fi
     echo "Alpine $alpine_version"
   else
-    debian_version=$(docker exec --user=solr $container_name cat /etc/debian_version || true)
+    debian_version=$(docker exec --user=solr "$container_name" cat /etc/debian_version || true)
     if [[ -z $debian_version ]]; then
       echo "Could not get debian version from container $container_name"
-      container_cleanup $container_name
+      container_cleanup "$container_name"
       exit 1
     fi
     echo "Debian $debian_version"
   fi
 
   # check that the version of Solr matches the tag
-  changelog_version=$(docker exec --user=solr $container_name bash -c "grep '==========' /opt/solr/CHANGES.txt | head -n 1 |  awk '{print $2}' | tr -d '= '")
+  changelog_version=$(docker exec --user=solr "$container_name" bash -c "egrep '^==========* ' /opt/solr/CHANGES.txt | head -n 1 | tr -d '= '")
   echo "Solr version $changelog_version"
   if [[ $tag = "$TAG_LOCAL_BASE:latest" ]]; then
     solr_version_from_tag=$latest
@@ -162,7 +163,7 @@ function test_simple {
   fi
   if [[ $changelog_version != $solr_version_from_tag ]]; then
     echo "Solr version mismatch"
-    container_cleanup $container_name
+    container_cleanup "$container_name"
     exit 1
   fi
 
@@ -170,24 +171,24 @@ function test_simple {
   echo "Sleeping $SLEEP_SECS seconds..."
   sleep $SLEEP_SECS
   echo "Checking Solr is running"
-  status=$(docker exec $container_name /opt/docker-solr/scripts/wait-for-solr.sh)
+  status=$(docker exec "$container_name" /opt/docker-solr/scripts/wait-for-solr.sh)
   if ! egrep -q 'solr is running' <<<$status; then
     echo "Test test_simple $tag failed; solr did not start"
-    container_cleanup $container_name
+    container_cleanup "$container_name"
     exit 1
   fi
   echo "Creating core"
-  docker exec --user=solr $container_name bin/solr create_core -c gettingstarted
+  docker exec --user=solr "$container_name" bin/solr create_core -c gettingstarted
   echo "Loading data"
-  docker exec --user=solr $container_name bin/post -c gettingstarted example/exampledocs/manufacturers.xml
+  docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
   sleep 1
   echo "Checking data"
-  data=$(docker exec --user=solr $container_name wget -q -O - http://localhost:8983/solr/gettingstarted/select'?q=*:*')
+  data=$(docker exec --user=solr "$container_name" wget -q -O - http://localhost:8983/solr/gettingstarted/select'?q=*:*')
   if ! egrep -q 'Round Rock' <<<$data; then
     echo "Test test_simple $tag failed; data did not load"
     exit 1
   fi
-  container_cleanup $container_name
+  container_cleanup "$container_name"
 
   echo "Test test_simple $tag succeeded"
 }
@@ -200,17 +201,17 @@ function push {
   let i=1
   while true; do
     echo "Pushing $push_tag (attempt $i)"
-    if docker push $push_tag; then
+    if docker push "$push_tag"; then
       echo "Pushed $push_tag"
       return
     else
       echo "Push $push_tag attempt $i failed"
-      if (( $i == $max_try )); then
+      if (( i == max_try )); then
         echo "Failed to push $push_tag in $max_try attempts; giving up"
         exit 1
       else
         echo "retrying in $wait_seconds seconds"
-        sleep $wait_seconds
+        sleep "$wait_seconds"
       fi
     fi
     let "i++"
@@ -243,7 +244,7 @@ function push_all {
   echo "current docker-solr images on this machine:"
   docker images | grep docker-solr
 
-  for full_version in ${versions[@]}; do
+  for full_version in "${versions[@]}"; do
     for tag in ${tags_for_version[$full_version]}; do
       cmd="docker tag $TAG_LOCAL_BASE:$tag $TAG_PUSH_BASE:$tag"
       echo "tagging: $cmd"
@@ -256,19 +257,19 @@ function push_all {
 }
 
 function build_all {
-  for full_version in ${versions[@]}; do
-    build $full_version ${dir_for_version[$full_version]} ${tags_for_version[$full_version]}
+  for full_version in "${versions[@]}"; do
+    build "$full_version" "${dir_for_version[$full_version]}" "${tags_for_version[$full_version]}"
   done
   echo "all docker-solr images:"
   docker images | grep docker-solr
 }
 
 function build_latest {
-  build $latest ${dir_for_version[$latest]} ${tags_for_version[$latest]}
+  build "$latest" "${dir_for_version[$latest]}" "${tags_for_version[$latest]}"
 }
 
 function test_all {
-  for full_version in ${versions[@]}; do
+  for full_version in "${versions[@]}"; do
     test_simple "$TAG_LOCAL_BASE:$full_version"
   done
 }
@@ -283,7 +284,7 @@ get_versions
 if [[ $# -eq 0 ]] ; then
   args="build_all"
 else
-  args="$@"
+  args="$(join_by ' ' $@)"
 fi
 for arg in $args; do
   case $arg in

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -76,7 +76,7 @@ join() {
 }
 
 for version in "${versions[@]}"; do
-	for variant in '' alpine; do
+	for variant in '' alpine slim; do
 		dir="$version${variant:+/$variant}"
 		[ -f "$dir/Dockerfile" ] || continue
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -61,7 +61,7 @@ join() {
 for version in "${versions[@]}"; do
 	commit="$(dirCommit "$version")"
 
-	fullVersion="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "ENV" && $2 == "ELASTICSEARCH_VERSION" { gsub(/~/, "-", $3); print $3; exit }')"
+	fullVersion="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "ENV" && $2 == "SOLR_VERSION" { gsub(/~/, "-", $3); print $3; exit }')"
 
 	rcVersion="${version%-rc}"
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,51 +1,101 @@
 #!/bin/bash
-set -e
+#
+# Based on https://github.com/docker-library/elasticsearch/blob/master/generate-stackbrew-library.sh
+set -eu
 
-declare -A aliases
-aliases=(
-        [6.6]='6 latest'
-        [5.5]='5'
+declare -A aliases=(
+    [6.6]='6 latest'
+    [5.5]='5'
 )
 
+self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+extglob_old=$(shopt -p extglob||true)
+shopt -s extglob
 
-versions=( */ )
+versions=( +([0-9])\.+([0-9])/ )
+eval "$extglob_old"
+
 versions=( "${versions[@]%/}" )
-url='git://github.com/docker-solr/docker-solr'
 
-echo '# maintainer: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66)'
-echo '# maintainer: Shalin Mangar <shalin@apache.org> (@shalinmangar)'
+# sort version numbers with highest first
+IFS=$'\n'; versions=( $(echo "${versions[*]}" | sort -rV) ); unset IFS
+
+# get the most recent commit which modified any of "$@"
+fileCommit() {
+	git log -1 --format='format:%H' HEAD -- "$@"
+}
+
+# get the most recent commit which modified "$1/Dockerfile" or any file COPY'd from "$1/Dockerfile"
+dirCommit() {
+	local dir="$1"; shift
+	(
+		cd "$dir"
+		fileCommit \
+			Dockerfile \
+			$(git show HEAD:./Dockerfile | awk '
+				toupper($1) == "COPY" {
+					for (i = 2; i < NF; i++) {
+						print $i
+					}
+				}
+			')
+	)
+}
+
+cat <<-EOH
+# this file is generated via https://github.com/docker-library/solr/blob/$(fileCommit "$self")/$self
+
+Maintainers: Martijn Koster <mak-github@greenhills.co.uk> (@makuk66),
+             Shalin Mangar <shalin@apache.org> (@shalinmangar)
+GitRepo: https://github.com/docker-solr/docker-solr.git
+EOH
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
 
 for version in "${versions[@]}"; do
-        if [ ! -f "$version/Dockerfile" ]; then
-          continue
-        fi
+	commit="$(dirCommit "$version")"
 
-	commit="$(git log -1 --format='format:%H' -- "$version")"
-	fullVersion="$(grep -m1 'ENV SOLR_VERSION' "$version/Dockerfile" | cut -d' ' -f3)"
-	
+	fullVersion="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "ENV" && $2 == "ELASTICSEARCH_VERSION" { gsub(/~/, "-", $3); print $3; exit }')"
+
+	rcVersion="${version%-rc}"
+
 	versionAliases=()
-	while [ "$fullVersion" != "$version" -a "${fullVersion%[.-]*}" != "$fullVersion" ]; do
+	while [ "$fullVersion" != "$rcVersion" -a "${fullVersion%[.-]*}" != "$fullVersion" ]; do
 		versionAliases+=( $fullVersion )
 		fullVersion="${fullVersion%[.-]*}"
 	done
-	versionAliases+=( $version ${aliases[$version]} )
-	
+	versionAliases+=(
+		$rcVersion
+		${aliases[$version]:-}
+	)
+
 	echo
-	for va in "${versionAliases[@]}"; do
-		echo "$va: ${url}@${commit} $version"
-	done
+	cat <<-EOE
+		Tags: $(join ', ' "${versionAliases[@]}")
+		Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+		GitCommit: $commit
+		Directory: $version
+	EOE
 
 	for variant in alpine; do
-		commit="$(git log -1 --format='format:%H' -- "$version/$variant")"
+		[ -f "$version/$variant/Dockerfile" ] || continue
+
+		commit="$(dirCommit "$version/$variant")"
+
+		variantAliases=( "${versionAliases[@]/%/-$variant}" )
+		variantAliases=( "${variantAliases[@]//latest-/}" )
+
 		echo
-		for va in "${versionAliases[@]}"; do
-			if [ "$va" = 'latest' ]; then
-				va="$variant"
-			else
-				va="$va-$variant"
-			fi
-			echo "$va: ${url}@${commit} $version/$variant"
-		done
+		cat <<-EOE
+			Tags: $(join ', ' "${variantAliases[@]}")
+			GitCommit: $commit
+			Directory: $version/$variant
+		EOE
 	done
 done

--- a/update.sh
+++ b/update.sh
@@ -37,6 +37,7 @@ function write_files {
         template=Dockerfile-$variant.template
     fi
 
+    echo "generating $target_dir"
     mkdir -p "$target_dir"
     <"$template" sed -r \
       -e 's/^(ENV SOLR_VERSION) .*/\1 '"$full_version"'/' \
@@ -232,6 +233,7 @@ for version in "${versions[@]}"; do
 
     write_files "$full_version"
     write_files "$full_version" 'alpine'
+    write_files "$full_version" 'slim'
     echo
 done
 


### PR DESCRIPTION
Update generate-stackbrew-library.sh to the latest from
https://github.com/docker-library/official-images/blob/master/library/elasticsearch
which uses RFC 2822 format.
Additional tweak to skip non-version directories.

Add other architectures supported by
https://github.com/docker-library/official-images/blob/master/library/openjdk

For https://github.com/docker-solr/docker-solr/issues/128