### PR TITLE
Improve --user invocation with INIT_SOLR_HOME

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -46,6 +46,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 ARG SOLR_DOWNLOAD_SERVER
 
 RUN apt-get update && \
-  apt-get -y install lsof procps && \
+  apt-get -y install lsof procps wget gpg && \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER solr

--- a/5.5/alpine/Dockerfile
+++ b/5.5/alpine/Dockerfile
@@ -53,6 +53,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/5.5/alpine/scripts/solr-create
+++ b/5.5/alpine/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/5.5/alpine/scripts/solr-demo
+++ b/5.5/alpine/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/5.5/alpine/scripts/start-local-solr
+++ b/5.5/alpine/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/5.5/alpine/scripts/stop-local-solr
+++ b/5.5/alpine/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/5.5/scripts/solr-create
+++ b/5.5/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/5.5/scripts/solr-demo
+++ b/5.5/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/5.5/scripts/start-local-solr
+++ b/5.5/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/5.5/scripts/stop-local-solr
+++ b/5.5/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/5.5/slim/Dockerfile
+++ b/5.5/slim/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    openjdk:8-jre
+FROM    openjdk:8-jre-slim
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:
@@ -16,10 +16,10 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -G $SOLR_USER -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 6.6.0
+ENV SOLR_VERSION 5.5.4
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
-ENV SOLR_SHA256 6b1d1ed0b74aef320633b40a38a790477e00d75b56b9cdc578533235315ffa1e
-ENV SOLR_KEYS 2085660D9C1FCCACC4A479A3BF160FF14992A24C
+ENV SOLR_SHA256 c1528e4afc9a0b8e7e5be0a16f40bb4080f410d502cd63b4447d448c49e9f500
+ENV SOLR_KEYS E6E21FFCDCEA14C95910EA65051A0FAF76BC6507
 
 RUN set -e; for key in $SOLR_KEYS; do \
     found=''; \
@@ -46,8 +46,6 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
-  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
-  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/5.5/slim/Dockerfile
+++ b/5.5/slim/Dockerfile
@@ -46,6 +46,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/5.5/slim/scripts/docker-entrypoint.sh
+++ b/5.5/slim/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/5.5/slim/scripts/init-solr-home
+++ b/5.5/slim/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/5.5/slim/scripts/run-initdb
+++ b/5.5/slim/scripts/run-initdb
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    fpath="/docker-entrypoint-initdb.d/$f"
+    case "$f" in
+        *.sh)     echo "$0: running $fpath"; . "$fpath" ;;
+        *)        echo "$0: ignoring $fpath" ;;
+    esac
+    echo
+done < <(ls /docker-entrypoint-initdb.d/ | sort -n)

--- a/5.5/slim/scripts/solr-create
+++ b/5.5/slim/scripts/solr-create
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
+
+set -e
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/core_created
+if [ -f $sentinel ]; then
+    echo "skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with: ${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with: ${@:1}"
+    stop-local-solr
+    touch $sentinel
+fi
+exec solr -f

--- a/5.5/slim/scripts/solr-create
+++ b/5.5/slim/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/5.5/slim/scripts/solr-demo
+++ b/5.5/slim/scripts/solr-demo
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/demo_created
+if [ -f $sentinel ]; then
+  echo "skipping demo creation"
+else
+  CORE=demo
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+  touch $sentinel
+fi
+
+exec solr -f

--- a/5.5/slim/scripts/solr-demo
+++ b/5.5/slim/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/5.5/slim/scripts/solr-foreground
+++ b/5.5/slim/scripts/solr-foreground
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+exec solr -f "$@"

--- a/5.5/slim/scripts/solr-precreate
+++ b/5.5/slim/scripts/solr-precreate
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r $CONFIG_SOURCE/ $coredir
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi
+exec solr -f

--- a/5.5/slim/scripts/start-local-solr
+++ b/5.5/slim/scripts/start-local-solr
@@ -1,0 +1,25 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Configuring Solr to bind to 127.0.0.1"
+cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
+echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+
+echo "Running solr in the background. Logs are in /opt/solr/server/logs"
+solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f /opt/solr/server/logs/solr.log ]; then
+        echo "Here is the log:"
+        cat /opt/solr/server/logs/solr.log
+    fi
+    exit 1
+fi

--- a/5.5/slim/scripts/start-local-solr
+++ b/5.5/slim/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/5.5/slim/scripts/stop-local-solr
+++ b/5.5/slim/scripts/stop-local-solr
@@ -1,0 +1,14 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop
+
+echo "Restoring Solr configuration"
+mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/5.5/slim/scripts/stop-local-solr
+++ b/5.5/slim/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/5.5/slim/scripts/wait-for-solr.sh
+++ b/5.5/slim/scripts/wait-for-solr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [ max_try [ wait_seconds ] ]
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo $@
+  echo "$0 [ max_try [ wait_seconds ] ]"
+  exit 1
+}
+
+max_try=$1
+if [[ -z $max_try ]]; then
+  max_try=12
+else
+  grep -q -E '^[0-9]+$' <<<$max_try || usage "$max_try is not a number"
+fi
+wait_seconds=$2
+if [[ -z $wait_seconds ]]; then
+  wait_seconds=5
+else
+  grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "$wait_seconds is not a number"
+fi
+let i=1
+until wget -q -O - http://localhost:8983 | grep -q -i solr; do
+  echo "solr is not running yet"
+  if (( $i == $max_try )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  let "i++"
+  sleep $wait_seconds
+done
+echo "solr is running"

--- a/6.3/Dockerfile
+++ b/6.3/Dockerfile
@@ -46,6 +46,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.3/Dockerfile
+++ b/6.3/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 ARG SOLR_DOWNLOAD_SERVER
 
 RUN apt-get update && \
-  apt-get -y install lsof procps && \
+  apt-get -y install lsof procps wget gpg && \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER solr

--- a/6.3/alpine/Dockerfile
+++ b/6.3/alpine/Dockerfile
@@ -53,6 +53,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.3/alpine/scripts/solr-create
+++ b/6.3/alpine/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/6.3/alpine/scripts/solr-demo
+++ b/6.3/alpine/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/6.3/alpine/scripts/start-local-solr
+++ b/6.3/alpine/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/6.3/alpine/scripts/stop-local-solr
+++ b/6.3/alpine/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.3/scripts/solr-create
+++ b/6.3/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/6.3/scripts/solr-demo
+++ b/6.3/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/6.3/scripts/start-local-solr
+++ b/6.3/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/6.3/scripts/stop-local-solr
+++ b/6.3/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.3/slim/Dockerfile
+++ b/6.3/slim/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    openjdk:8-jre
+FROM    openjdk:8-jre-slim
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:
@@ -16,10 +16,10 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -G $SOLR_USER -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 6.6.0
+ENV SOLR_VERSION 6.3.0
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
-ENV SOLR_SHA256 6b1d1ed0b74aef320633b40a38a790477e00d75b56b9cdc578533235315ffa1e
-ENV SOLR_KEYS 2085660D9C1FCCACC4A479A3BF160FF14992A24C
+ENV SOLR_SHA256 07692257575fe54ddb8a8f64e96d3d352f2f533aa91b5752be1869d2acf2f544
+ENV SOLR_KEYS 38D2EA16DDF5FC722EBC433FDC92616F177050F6
 
 RUN set -e; for key in $SOLR_KEYS; do \
     found=''; \
@@ -46,8 +46,6 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
-  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
-  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.3/slim/Dockerfile
+++ b/6.3/slim/Dockerfile
@@ -46,6 +46,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.3/slim/scripts/docker-entrypoint.sh
+++ b/6.3/slim/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/6.3/slim/scripts/init-solr-home
+++ b/6.3/slim/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/6.3/slim/scripts/run-initdb
+++ b/6.3/slim/scripts/run-initdb
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    fpath="/docker-entrypoint-initdb.d/$f"
+    case "$f" in
+        *.sh)     echo "$0: running $fpath"; . "$fpath" ;;
+        *)        echo "$0: ignoring $fpath" ;;
+    esac
+    echo
+done < <(ls /docker-entrypoint-initdb.d/ | sort -n)

--- a/6.3/slim/scripts/solr-create
+++ b/6.3/slim/scripts/solr-create
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
+
+set -e
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/core_created
+if [ -f $sentinel ]; then
+    echo "skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with: ${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with: ${@:1}"
+    stop-local-solr
+    touch $sentinel
+fi
+exec solr -f

--- a/6.3/slim/scripts/solr-create
+++ b/6.3/slim/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/6.3/slim/scripts/solr-demo
+++ b/6.3/slim/scripts/solr-demo
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/demo_created
+if [ -f $sentinel ]; then
+  echo "skipping demo creation"
+else
+  CORE=demo
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+  touch $sentinel
+fi
+
+exec solr -f

--- a/6.3/slim/scripts/solr-demo
+++ b/6.3/slim/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/6.3/slim/scripts/solr-foreground
+++ b/6.3/slim/scripts/solr-foreground
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+exec solr -f "$@"

--- a/6.3/slim/scripts/solr-precreate
+++ b/6.3/slim/scripts/solr-precreate
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r $CONFIG_SOURCE/ $coredir
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi
+exec solr -f

--- a/6.3/slim/scripts/start-local-solr
+++ b/6.3/slim/scripts/start-local-solr
@@ -1,0 +1,25 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Configuring Solr to bind to 127.0.0.1"
+cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
+echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+
+echo "Running solr in the background. Logs are in /opt/solr/server/logs"
+solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f /opt/solr/server/logs/solr.log ]; then
+        echo "Here is the log:"
+        cat /opt/solr/server/logs/solr.log
+    fi
+    exit 1
+fi

--- a/6.3/slim/scripts/start-local-solr
+++ b/6.3/slim/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/6.3/slim/scripts/stop-local-solr
+++ b/6.3/slim/scripts/stop-local-solr
@@ -1,0 +1,14 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop
+
+echo "Restoring Solr configuration"
+mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.3/slim/scripts/stop-local-solr
+++ b/6.3/slim/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.3/slim/scripts/wait-for-solr.sh
+++ b/6.3/slim/scripts/wait-for-solr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [ max_try [ wait_seconds ] ]
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo $@
+  echo "$0 [ max_try [ wait_seconds ] ]"
+  exit 1
+}
+
+max_try=$1
+if [[ -z $max_try ]]; then
+  max_try=12
+else
+  grep -q -E '^[0-9]+$' <<<$max_try || usage "$max_try is not a number"
+fi
+wait_seconds=$2
+if [[ -z $wait_seconds ]]; then
+  wait_seconds=5
+else
+  grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "$wait_seconds is not a number"
+fi
+let i=1
+until wget -q -O - http://localhost:8983 | grep -q -i solr; do
+  echo "solr is not running yet"
+  if (( $i == $max_try )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  let "i++"
+  sleep $wait_seconds
+done
+echo "solr is running"

--- a/6.4/Dockerfile
+++ b/6.4/Dockerfile
@@ -46,6 +46,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.4/Dockerfile
+++ b/6.4/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 ARG SOLR_DOWNLOAD_SERVER
 
 RUN apt-get update && \
-  apt-get -y install lsof procps && \
+  apt-get -y install lsof procps wget gpg && \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER solr

--- a/6.4/alpine/Dockerfile
+++ b/6.4/alpine/Dockerfile
@@ -53,6 +53,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.4/alpine/scripts/solr-create
+++ b/6.4/alpine/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/6.4/alpine/scripts/solr-demo
+++ b/6.4/alpine/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/6.4/alpine/scripts/start-local-solr
+++ b/6.4/alpine/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/6.4/alpine/scripts/stop-local-solr
+++ b/6.4/alpine/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.4/scripts/solr-create
+++ b/6.4/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/6.4/scripts/solr-demo
+++ b/6.4/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/6.4/scripts/start-local-solr
+++ b/6.4/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/6.4/scripts/stop-local-solr
+++ b/6.4/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.4/slim/Dockerfile
+++ b/6.4/slim/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    openjdk:8-jre
+FROM    openjdk:8-jre-slim
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:
@@ -16,9 +16,9 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -G $SOLR_USER -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 6.6.0
+ENV SOLR_VERSION 6.4.2
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
-ENV SOLR_SHA256 6b1d1ed0b74aef320633b40a38a790477e00d75b56b9cdc578533235315ffa1e
+ENV SOLR_SHA256 354e1affd9cad7d6e86cde8c03aaeb604876f0764129621d8e231cdb35b31c55
 ENV SOLR_KEYS 2085660D9C1FCCACC4A479A3BF160FF14992A24C
 
 RUN set -e; for key in $SOLR_KEYS; do \
@@ -46,8 +46,6 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
-  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
-  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.4/slim/Dockerfile
+++ b/6.4/slim/Dockerfile
@@ -46,6 +46,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.4/slim/scripts/docker-entrypoint.sh
+++ b/6.4/slim/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/6.4/slim/scripts/init-solr-home
+++ b/6.4/slim/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/6.4/slim/scripts/run-initdb
+++ b/6.4/slim/scripts/run-initdb
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    fpath="/docker-entrypoint-initdb.d/$f"
+    case "$f" in
+        *.sh)     echo "$0: running $fpath"; . "$fpath" ;;
+        *)        echo "$0: ignoring $fpath" ;;
+    esac
+    echo
+done < <(ls /docker-entrypoint-initdb.d/ | sort -n)

--- a/6.4/slim/scripts/solr-create
+++ b/6.4/slim/scripts/solr-create
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
+
+set -e
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/core_created
+if [ -f $sentinel ]; then
+    echo "skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with: ${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with: ${@:1}"
+    stop-local-solr
+    touch $sentinel
+fi
+exec solr -f

--- a/6.4/slim/scripts/solr-create
+++ b/6.4/slim/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/6.4/slim/scripts/solr-demo
+++ b/6.4/slim/scripts/solr-demo
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/demo_created
+if [ -f $sentinel ]; then
+  echo "skipping demo creation"
+else
+  CORE=demo
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+  touch $sentinel
+fi
+
+exec solr -f

--- a/6.4/slim/scripts/solr-demo
+++ b/6.4/slim/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/6.4/slim/scripts/solr-foreground
+++ b/6.4/slim/scripts/solr-foreground
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+exec solr -f "$@"

--- a/6.4/slim/scripts/solr-precreate
+++ b/6.4/slim/scripts/solr-precreate
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r $CONFIG_SOURCE/ $coredir
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi
+exec solr -f

--- a/6.4/slim/scripts/start-local-solr
+++ b/6.4/slim/scripts/start-local-solr
@@ -1,0 +1,25 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Configuring Solr to bind to 127.0.0.1"
+cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
+echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+
+echo "Running solr in the background. Logs are in /opt/solr/server/logs"
+solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f /opt/solr/server/logs/solr.log ]; then
+        echo "Here is the log:"
+        cat /opt/solr/server/logs/solr.log
+    fi
+    exit 1
+fi

--- a/6.4/slim/scripts/start-local-solr
+++ b/6.4/slim/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/6.4/slim/scripts/stop-local-solr
+++ b/6.4/slim/scripts/stop-local-solr
@@ -1,0 +1,14 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop
+
+echo "Restoring Solr configuration"
+mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.4/slim/scripts/stop-local-solr
+++ b/6.4/slim/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.4/slim/scripts/wait-for-solr.sh
+++ b/6.4/slim/scripts/wait-for-solr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [ max_try [ wait_seconds ] ]
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo $@
+  echo "$0 [ max_try [ wait_seconds ] ]"
+  exit 1
+}
+
+max_try=$1
+if [[ -z $max_try ]]; then
+  max_try=12
+else
+  grep -q -E '^[0-9]+$' <<<$max_try || usage "$max_try is not a number"
+fi
+wait_seconds=$2
+if [[ -z $wait_seconds ]]; then
+  wait_seconds=5
+else
+  grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "$wait_seconds is not a number"
+fi
+let i=1
+until wget -q -O - http://localhost:8983 | grep -q -i solr; do
+  echo "solr is not running yet"
+  if (( $i == $max_try )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  let "i++"
+  sleep $wait_seconds
+done
+echo "solr is running"

--- a/6.5/Dockerfile
+++ b/6.5/Dockerfile
@@ -46,6 +46,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.5/Dockerfile
+++ b/6.5/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 ARG SOLR_DOWNLOAD_SERVER
 
 RUN apt-get update && \
-  apt-get -y install lsof procps && \
+  apt-get -y install lsof procps wget gpg && \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER solr

--- a/6.5/alpine/Dockerfile
+++ b/6.5/alpine/Dockerfile
@@ -53,6 +53,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.5/alpine/scripts/solr-create
+++ b/6.5/alpine/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/6.5/alpine/scripts/solr-demo
+++ b/6.5/alpine/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/6.5/alpine/scripts/start-local-solr
+++ b/6.5/alpine/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/6.5/alpine/scripts/stop-local-solr
+++ b/6.5/alpine/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.5/scripts/solr-create
+++ b/6.5/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/6.5/scripts/solr-demo
+++ b/6.5/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/6.5/scripts/start-local-solr
+++ b/6.5/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/6.5/scripts/stop-local-solr
+++ b/6.5/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.5/slim/Dockerfile
+++ b/6.5/slim/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    openjdk:8-jre
+FROM    openjdk:8-jre-slim
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:
@@ -16,10 +16,10 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -G $SOLR_USER -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 6.6.0
+ENV SOLR_VERSION 6.5.1
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
-ENV SOLR_SHA256 6b1d1ed0b74aef320633b40a38a790477e00d75b56b9cdc578533235315ffa1e
-ENV SOLR_KEYS 2085660D9C1FCCACC4A479A3BF160FF14992A24C
+ENV SOLR_SHA256 7c6a7d4474d5e847a8ddd0a4717d33bf5db07adf17c3d36ad1532c72885bd5d3
+ENV SOLR_KEYS 052C5B48A480B9CEA9E218A5F98C13CFA5A135D8
 
 RUN set -e; for key in $SOLR_KEYS; do \
     found=''; \
@@ -46,8 +46,6 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
-  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
-  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.5/slim/Dockerfile
+++ b/6.5/slim/Dockerfile
@@ -46,6 +46,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.5/slim/scripts/docker-entrypoint.sh
+++ b/6.5/slim/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/6.5/slim/scripts/init-solr-home
+++ b/6.5/slim/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/6.5/slim/scripts/run-initdb
+++ b/6.5/slim/scripts/run-initdb
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    fpath="/docker-entrypoint-initdb.d/$f"
+    case "$f" in
+        *.sh)     echo "$0: running $fpath"; . "$fpath" ;;
+        *)        echo "$0: ignoring $fpath" ;;
+    esac
+    echo
+done < <(ls /docker-entrypoint-initdb.d/ | sort -n)

--- a/6.5/slim/scripts/solr-create
+++ b/6.5/slim/scripts/solr-create
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
+
+set -e
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/core_created
+if [ -f $sentinel ]; then
+    echo "skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with: ${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with: ${@:1}"
+    stop-local-solr
+    touch $sentinel
+fi
+exec solr -f

--- a/6.5/slim/scripts/solr-create
+++ b/6.5/slim/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/6.5/slim/scripts/solr-demo
+++ b/6.5/slim/scripts/solr-demo
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/demo_created
+if [ -f $sentinel ]; then
+  echo "skipping demo creation"
+else
+  CORE=demo
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+  touch $sentinel
+fi
+
+exec solr -f

--- a/6.5/slim/scripts/solr-demo
+++ b/6.5/slim/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/6.5/slim/scripts/solr-foreground
+++ b/6.5/slim/scripts/solr-foreground
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+exec solr -f "$@"

--- a/6.5/slim/scripts/solr-precreate
+++ b/6.5/slim/scripts/solr-precreate
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r $CONFIG_SOURCE/ $coredir
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi
+exec solr -f

--- a/6.5/slim/scripts/start-local-solr
+++ b/6.5/slim/scripts/start-local-solr
@@ -1,0 +1,25 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Configuring Solr to bind to 127.0.0.1"
+cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
+echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+
+echo "Running solr in the background. Logs are in /opt/solr/server/logs"
+solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f /opt/solr/server/logs/solr.log ]; then
+        echo "Here is the log:"
+        cat /opt/solr/server/logs/solr.log
+    fi
+    exit 1
+fi

--- a/6.5/slim/scripts/start-local-solr
+++ b/6.5/slim/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/6.5/slim/scripts/stop-local-solr
+++ b/6.5/slim/scripts/stop-local-solr
@@ -1,0 +1,14 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop
+
+echo "Restoring Solr configuration"
+mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.5/slim/scripts/stop-local-solr
+++ b/6.5/slim/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.5/slim/scripts/wait-for-solr.sh
+++ b/6.5/slim/scripts/wait-for-solr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [ max_try [ wait_seconds ] ]
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo $@
+  echo "$0 [ max_try [ wait_seconds ] ]"
+  exit 1
+}
+
+max_try=$1
+if [[ -z $max_try ]]; then
+  max_try=12
+else
+  grep -q -E '^[0-9]+$' <<<$max_try || usage "$max_try is not a number"
+fi
+wait_seconds=$2
+if [[ -z $wait_seconds ]]; then
+  wait_seconds=5
+else
+  grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "$wait_seconds is not a number"
+fi
+let i=1
+until wget -q -O - http://localhost:8983 | grep -q -i solr; do
+  echo "solr is not running yet"
+  if (( $i == $max_try )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  let "i++"
+  sleep $wait_seconds
+done
+echo "solr is running"

--- a/6.6/Dockerfile
+++ b/6.6/Dockerfile
@@ -46,6 +46,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.6/alpine/Dockerfile
+++ b/6.6/alpine/Dockerfile
@@ -53,6 +53,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.6/alpine/scripts/solr-create
+++ b/6.6/alpine/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/6.6/alpine/scripts/solr-demo
+++ b/6.6/alpine/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/6.6/alpine/scripts/start-local-solr
+++ b/6.6/alpine/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/6.6/alpine/scripts/stop-local-solr
+++ b/6.6/alpine/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.6/scripts/solr-create
+++ b/6.6/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/6.6/scripts/solr-demo
+++ b/6.6/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/6.6/scripts/start-local-solr
+++ b/6.6/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/6.6/scripts/stop-local-solr
+++ b/6.6/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.6/slim/Dockerfile
+++ b/6.6/slim/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM    openjdk:8-jre
+FROM    openjdk:8-jre-slim
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:
@@ -46,8 +46,6 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
-  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
-  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.6/slim/Dockerfile
+++ b/6.6/slim/Dockerfile
@@ -46,6 +46,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/6.6/slim/scripts/docker-entrypoint.sh
+++ b/6.6/slim/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/6.6/slim/scripts/init-solr-home
+++ b/6.6/slim/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ $(find "$SOLR_HOME" -mindepth  1 | wc -l) != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/6.6/slim/scripts/run-initdb
+++ b/6.6/slim/scripts/run-initdb
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    fpath="/docker-entrypoint-initdb.d/$f"
+    case "$f" in
+        *.sh)     echo "$0: running $fpath"; . "$fpath" ;;
+        *)        echo "$0: ignoring $fpath" ;;
+    esac
+    echo
+done < <(ls /docker-entrypoint-initdb.d/ | sort -n)

--- a/6.6/slim/scripts/solr-create
+++ b/6.6/slim/scripts/solr-create
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
+
+set -e
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/core_created
+if [ -f $sentinel ]; then
+    echo "skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with: ${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with: ${@:1}"
+    stop-local-solr
+    touch $sentinel
+fi
+exec solr -f

--- a/6.6/slim/scripts/solr-create
+++ b/6.6/slim/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/6.6/slim/scripts/solr-demo
+++ b/6.6/slim/scripts/solr-demo
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+sentinel=/opt/docker-solr/demo_created
+if [ -f $sentinel ]; then
+  echo "skipping demo creation"
+else
+  CORE=demo
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+  touch $sentinel
+fi
+
+exec solr -f

--- a/6.6/slim/scripts/solr-demo
+++ b/6.6/slim/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/6.6/slim/scripts/solr-foreground
+++ b/6.6/slim/scripts/solr-foreground
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+exec solr -f "$@"

--- a/6.6/slim/scripts/solr-precreate
+++ b/6.6/slim/scripts/solr-precreate
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE=${2:-'/opt/solr/server/solr/configsets/data_driven_schema_configs'}
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r $CONFIG_SOURCE/ $coredir
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi
+exec solr -f

--- a/6.6/slim/scripts/start-local-solr
+++ b/6.6/slim/scripts/start-local-solr
@@ -1,0 +1,25 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Configuring Solr to bind to 127.0.0.1"
+cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
+echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+
+echo "Running solr in the background. Logs are in /opt/solr/server/logs"
+solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f /opt/solr/server/logs/solr.log ]; then
+        echo "Here is the log:"
+        cat /opt/solr/server/logs/solr.log
+    fi
+    exit 1
+fi

--- a/6.6/slim/scripts/start-local-solr
+++ b/6.6/slim/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/6.6/slim/scripts/stop-local-solr
+++ b/6.6/slim/scripts/stop-local-solr
@@ -1,0 +1,14 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop
+
+echo "Restoring Solr configuration"
+mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.6/slim/scripts/stop-local-solr
+++ b/6.6/slim/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/6.6/slim/scripts/wait-for-solr.sh
+++ b/6.6/slim/scripts/wait-for-solr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [ max_try [ wait_seconds ] ]
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo $@
+  echo "$0 [ max_try [ wait_seconds ] ]"
+  exit 1
+}
+
+max_try=$1
+if [[ -z $max_try ]]; then
+  max_try=12
+else
+  grep -q -E '^[0-9]+$' <<<$max_try || usage "$max_try is not a number"
+fi
+wait_seconds=$2
+if [[ -z $wait_seconds ]]; then
+  wait_seconds=5
+else
+  grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "$wait_seconds is not a number"
+fi
+let i=1
+until wget -q -O - http://localhost:8983 | grep -q -i solr; do
+  echo "solr is not running yet"
+  if (( $i == $max_try )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  let "i++"
+  sleep $wait_seconds
+done
+echo "solr is running"

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -53,6 +53,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -1,5 +1,5 @@
 
-FROM    openjdk:8-jre
+FROM    openjdk:8-jre-slim
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
 # Override the solr download location with e.g.:
@@ -16,10 +16,10 @@ ENV SOLR_UID 8983
 RUN groupadd -r -g $SOLR_UID $SOLR_USER && \
   useradd -r -u $SOLR_UID -G $SOLR_USER -g $SOLR_USER $SOLR_USER
 
-ENV SOLR_VERSION 6.6.0
+ENV SOLR_VERSION version-goes-here
 ENV SOLR_URL ${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$SOLR_VERSION/solr-$SOLR_VERSION.tgz
-ENV SOLR_SHA256 6b1d1ed0b74aef320633b40a38a790477e00d75b56b9cdc578533235315ffa1e
-ENV SOLR_KEYS 2085660D9C1FCCACC4A479A3BF160FF14992A24C
+ENV SOLR_SHA256 checksum-goes-here
+ENV SOLR_KEYS fingerprint-goes-here
 
 RUN set -e; for key in $SOLR_KEYS; do \
     found=''; \
@@ -46,8 +46,6 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
-  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
-  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -46,6 +46,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -46,6 +46,8 @@ RUN mkdir -p /opt/solr && \
   rm /opt/solr.tgz* && \
   rm -Rf /opt/solr/docs/ && \
   mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
   sed -i -e 's/#SOLR_PORT=8983/SOLR_PORT=8983/' /opt/solr/bin/solr.in.sh && \
   sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
   chown -R $SOLR_USER:$SOLR_USER /opt/solr && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -7,7 +7,7 @@ MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 ARG SOLR_DOWNLOAD_SERVER
 
 RUN apt-get update && \
-  apt-get -y install lsof procps && \
+  apt-get -y install lsof procps wget gpg && \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER solr

--- a/scripts/solr-create
+++ b/scripts/solr-create
@@ -7,22 +7,36 @@
 #      docker run -P -d solr solr-create -c mycore
 # To create a core from mounted config:
 #      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
-# To create a core in a mounted directory:
-#      mkdir mycores; chown 8983:8983 mycores
-#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-create -c mycore
 
-set -e
+set -euo pipefail
 echo "Executing $0 $@"
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/core_created
-if [ -f $sentinel ]; then
-    echo "skipping core creation"
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
 else
     start-local-solr
 
@@ -38,6 +52,11 @@ else
 
     echo "Created core with: ${@:1}"
     stop-local-solr
-    touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 exec solr -f

--- a/scripts/solr-demo
+++ b/scripts/solr-demo
@@ -2,19 +2,19 @@
 #
 # Configure a Solr demo and then run solr in the foreground
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
 . /opt/docker-solr/scripts/run-initdb
 
-sentinel=/opt/docker-solr/demo_created
-if [ -f $sentinel ]; then
-  echo "skipping demo creation"
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
 else
-  CORE=demo
   start-local-solr
   echo "Creating $CORE"
   /opt/solr/bin/solr create -c "$CORE"
@@ -25,7 +25,12 @@ else
   /opt/solr/bin/post -c $CORE example/exampledocs/books.csv
   echo "Loaded example data"
   stop-local-solr
-  touch $sentinel
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
 fi
 
 exec solr -f

--- a/scripts/start-local-solr
+++ b/scripts/start-local-solr
@@ -1,25 +1,42 @@
 #!/bin/bash
 # configure Solr to run on the local interface, and start it running in the background
 
-set -e
+set -euo pipefail
 
-if [[ "$VERBOSE" = "yes" ]]; then
+if [[ "${VERBOSE:-}" = "yes" ]]; then
     set -x
 fi
 
-echo "Configuring Solr to bind to 127.0.0.1"
-cp /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig
-echo "SOLR_OPTS=-Djetty.host=127.0.0.1" >> /opt/solr/bin/solr.in.sh
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
-echo "Running solr in the background. Logs are in /opt/solr/server/logs"
-solr start
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh "$max_try" "$wait_seconds"; then
     echo "Could not start Solr."
-    if [ -f /opt/solr/server/logs/solr.log ]; then
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
         echo "Here is the log:"
-        cat /opt/solr/server/logs/solr.log
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
     fi
     exit 1
 fi

--- a/scripts/stop-local-solr
+++ b/scripts/stop-local-solr
@@ -9,6 +9,3 @@ fi
 
 echo "Shutting down the background Solr"
 solr stop
-
-echo "Restoring Solr configuration"
-mv /opt/solr/bin/solr.in.sh.orig /opt/solr/bin/solr.in.sh

--- a/update.sh
+++ b/update.sh
@@ -37,6 +37,7 @@ function write_files {
         template=Dockerfile-$variant.template
     fi
 
+    echo "generating $target_dir"
     mkdir -p "$target_dir"
     <"$template" sed -r \
       -e 's/^(ENV SOLR_VERSION) .*/\1 '"$full_version"'/' \
@@ -232,6 +233,7 @@ for version in "${versions[@]}"; do
 
     write_files "$full_version"
     write_files "$full_version" 'alpine'
+    write_files "$full_version" 'slim'
     echo
 done
 


### PR DESCRIPTION
- change solr-create/solr-demo to not use sentinel files but look for the core directory
- change start-local-solr to write the PID to the logs directory if needed
- change start-local-solr to use SOLR_OPTS to limit the first JVM start to localhost,
  instead of writing a config file
- patch the bin/solr script to use `id` instead of `whoami` so it does not complain about missing /etc/password entries for the current user
- patch the bin/solr script to invoke lsof without complaining about missing /etc/password entries for the current user

  With these changes you can:

```
mkdir mysolrhome logs
docker run -it \
  --mount type=bind,source=$PWD/mysolrhome,destination=/mysolrhome \
  --mount type=bind,source=$PWD/logs,destination=/logs \
  -e VERBOSE=yes \
  -e SOLR_HOME=/mysolrhome \
  -e SOLR_LOGS_DIR=/logs \
  -e INIT_SOLR_HOME=yes \
  -u "$(id -u):$(id -g)" \
  solr solr-create -c books
```