### PR TITLE
Ignore lost+found when checking if SOLR_HOME is empty in init-solr-home

### DIFF
--- a/5.5/alpine/scripts/init-solr-home
+++ b/5.5/alpine/scripts/init-solr-home
@@ -39,7 +39,7 @@ if [ -f "$SOLR_HOME/solr.xml" ]; then
 fi
 
 # refuse to use non-empty directories, which are likely a misconfiguration
-if [ "$(find "$SOLR_HOME" -mindepth  1 | wc -l)" != '0' ]; then
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
     echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
     exit 1
 fi

--- a/5.5/scripts/init-solr-home
+++ b/5.5/scripts/init-solr-home
@@ -39,7 +39,7 @@ if [ -f "$SOLR_HOME/solr.xml" ]; then
 fi
 
 # refuse to use non-empty directories, which are likely a misconfiguration
-if [ "$(find "$SOLR_HOME" -mindepth  1 | wc -l)" != '0' ]; then
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
     echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
     exit 1
 fi

--- a/5.5/slim/scripts/init-solr-home
+++ b/5.5/slim/scripts/init-solr-home
@@ -39,7 +39,7 @@ if [ -f "$SOLR_HOME/solr.xml" ]; then
 fi
 
 # refuse to use non-empty directories, which are likely a misconfiguration
-if [ "$(find "$SOLR_HOME" -mindepth  1 | wc -l)" != '0' ]; then
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
     echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
     exit 1
 fi

--- a/6.3/alpine/scripts/init-solr-home
+++ b/6.3/alpine/scripts/init-solr-home
@@ -39,7 +39,7 @@ if [ -f "$SOLR_HOME/solr.xml" ]; then
 fi
 
 # refuse to use non-empty directories, which are likely a misconfiguration
-if [ "$(find "$SOLR_HOME" -mindepth  1 | wc -l)" != '0' ]; then
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
     echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
     exit 1
 fi

--- a/6.3/scripts/init-solr-home
+++ b/6.3/scripts/init-solr-home
@@ -39,7 +39,7 @@ if [ -f "$SOLR_HOME/solr.xml" ]; then
 fi
 
 # refuse to use non-empty directories, which are likely a misconfiguration
-if [ "$(find "$SOLR_HOME" -mindepth  1 | wc -l)" != '0' ]; then
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
     echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
     exit 1
 fi

--- a/6.3/slim/scripts/init-solr-home
+++ b/6.3/slim/scripts/init-solr-home
@@ -39,7 +39,7 @@ if [ -f "$SOLR_HOME/solr.xml" ]; then
 fi
 
 # refuse to use non-empty directories, which are likely a misconfiguration
-if [ "$(find "$SOLR_HOME" -mindepth  1 | wc -l)" != '0' ]; then
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
     echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
     exit 1
 fi

--- a/6.4/scripts/init-solr-home
+++ b/6.4/scripts/init-solr-home
@@ -39,7 +39,7 @@ if [ -f "$SOLR_HOME/solr.xml" ]; then
 fi
 
 # refuse to use non-empty directories, which are likely a misconfiguration
-if [ "$(find "$SOLR_HOME" -mindepth  1 | wc -l)" != '0' ]; then
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
     echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
     exit 1
 fi

--- a/7.1/scripts/init-solr-home
+++ b/7.1/scripts/init-solr-home
@@ -39,7 +39,7 @@ if [ -f "$SOLR_HOME/solr.xml" ]; then
 fi
 
 # refuse to use non-empty directories, which are likely a misconfiguration
-if [ "$(find "$SOLR_HOME" -mindepth  1 | wc -l)" != '0' ]; then
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
     echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
     exit 1
 fi

--- a/scripts/init-solr-home
+++ b/scripts/init-solr-home
@@ -39,7 +39,7 @@ if [ -f "$SOLR_HOME/solr.xml" ]; then
 fi
 
 # refuse to use non-empty directories, which are likely a misconfiguration
-if [ "$(find "$SOLR_HOME" -mindepth  1 | wc -l)" != '0' ]; then
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
     echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
     exit 1
 fi

--- a/tests/init_solr_home/test.sh
+++ b/tests/init_solr_home/test.sh
@@ -30,6 +30,7 @@ if [ -d mysolrhome ]; then
 fi
 
 mkdir mysolrhome
+mkdir mysolrhome/lost+found
 chmod a+w mysolrhome
 docker run --name "$container_name" -d -v "$PWD/mysolrhome:/mysolrhome" -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes -d "$tag" "solr-demo"
 


### PR DESCRIPTION
init-solr-home sensibly checks whether a directory is empty before attempting to copy /home/solr/server/solr into it.

This precaution causes trouble when the mounted volume is a Unix filesystem as they contain a lost+found directory used to put files that were misplaced by the filesystem.

Fixes #152 