### PR TITLE
Add centos based Solr images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ upstream_versions
 tests/tests_to_run
 mycores
 scripts.old
+/.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ jobs:
       script: tools/build_test_push.sh 7.2/alpine
     - stage: build, test, deploy
       env:
+      - PROCESS=7.2/centos
+      script: tools/build_test_push.sh 7.2/centos
+    - stage: build, test, deploy
+      env:
       - PROCESS=7.2
       script: tools/build_test_push.sh 7.2
     - stage: build, test, deploy
@@ -30,6 +34,10 @@ jobs:
       env:
       - PROCESS=7.1/alpine
       script: tools/build_test_push.sh 7.1/alpine
+    - stage: build, test, deploy
+      env:
+      - PROCESS=7.1/centos
+      script: tools/build_test_push.sh 7.1/centos
     - stage: build, test, deploy
       env:
       - PROCESS=7.1
@@ -44,6 +52,10 @@ jobs:
       script: tools/build_test_push.sh 6.6/alpine
     - stage: build, test, deploy
       env:
+      - PROCESS=6.6/centos
+      script: tools/build_test_push.sh 6.6/centos
+    - stage: build, test, deploy
+      env:
       - PROCESS=6.6
       script: tools/build_test_push.sh 6.6
     - stage: build, test, deploy
@@ -54,6 +66,10 @@ jobs:
       env:
       - PROCESS=5.5/alpine
       script: tools/build_test_push.sh 5.5/alpine
+    - stage: build, test, deploy
+      env:
+      - PROCESS=5.5/centos
+      script: tools/build_test_push.sh 5.5/centos
     - stage: build, test, deploy
       env:
       - PROCESS=5.5

--- a/5.5/centos/Dockerfile
+++ b/5.5/centos/Dockerfile
@@ -1,0 +1,80 @@
+
+ARG   CENTOS_PARENT_IMAGE=centos:7
+FROM  centos:7
+LABEL maintainer="Martijn Koster <mak-docker@greenhills.co.uk>"
+
+# there is no ready made jdk centos image, so we install java ourselves
+ENV JAVA_HOME="/etc/alternatives/jre" \
+    JAVA_VERSION="1.8.0"
+
+# /dev/urandom is used as random source, which is prefectly safe
+# according to http://www.2uo.de/myths-about-urandom/
+RUN yum install -y \
+       java-${JAVA_VERSION}-openjdk  \
+       java-${JAVA_VERSION}-openjdk-devel \
+    && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/java/jre/lib/security/java.security
+
+# Override the solr download location with e.g.:
+#   docker build -t mine --build-arg SOLR_DOWNLOAD_SERVER=http://www-eu.apache.org/dist/lucene/solr .
+ARG SOLR_DOWNLOAD_SERVER
+
+RUN yum update -y && \
+  yum -y install lsof procps wget gpg && \
+  yum clean all && \
+  rm -rf /var/cache/yum/*
+
+ENV SOLR_USER="solr" \
+    SOLR_UID="8983" \
+    SOLR_GROUP="solr" \
+    SOLR_GID="8983" \
+    SOLR_PORT="8983" \
+    SOLR_VERSION="5.5.5" \
+    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/5.5.5/solr-5.5.5.tgz" \
+    SOLR_SHA256="2bbe3a55976f118c5d8c2382d4591257f6e2af779c08c6561e44afa3181a87c1" \
+    SOLR_KEYS="5F55943E13D49059D3F342777186B06E1ED139E7" \
+    PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH"
+
+RUN groupadd -r --gid $SOLR_GID $SOLR_GROUP && \
+  useradd -r --uid $SOLR_UID --gid $SOLR_GID $SOLR_USER
+
+RUN set -e; for key in $SOLR_KEYS; do \
+    found=''; \
+    for server in \
+      ha.pool.sks-keyservers.net \
+      hkp://keyserver.ubuntu.com:80 \
+      hkp://p80.pool.sks-keyservers.net:80 \
+      pgp.mit.edu \
+    ; do \
+      echo "  trying $server for $key"; \
+      gpg --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch $key from several disparate servers -- network issues?" && exit 1; \
+  done; \
+  exit 0
+
+RUN mkdir -p /opt/solr && \
+  echo "downloading $SOLR_URL" && \
+  wget -nv $SOLR_URL -O /opt/solr.tgz && \
+  echo "downloading $SOLR_URL.asc" && \
+  wget -nv $SOLR_URL.asc -O /opt/solr.tgz.asc && \
+  echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \
+  (>&2 ls -l /opt/solr.tgz /opt/solr.tgz.asc) && \
+  gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \
+  tar -C /opt/solr --extract --file /opt/solr.tgz --strip-components=1 && \
+  rm /opt/solr.tgz* && \
+  rm -Rf /opt/solr/docs/ && \
+  mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores /opt/solr/server/logs /docker-entrypoint-initdb.d /opt/docker-solr && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
+  sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
+  chown -R $SOLR_USER:$SOLR_GROUP /opt/solr
+
+COPY scripts /opt/docker-solr/scripts
+RUN chown -R $SOLR_USER:$SOLR_GROUP /opt/docker-solr
+
+EXPOSE ${SOLR_PORT}
+WORKDIR /opt/solr
+USER $SOLR_USER
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["solr-foreground"]

--- a/5.5/centos/scripts/docker-entrypoint.sh
+++ b/5.5/centos/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/5.5/centos/scripts/init-solr-home
+++ b/5.5/centos/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/5.5/centos/scripts/precreate-core
+++ b/5.5/centos/scripts/precreate-core
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Create a core on disk
+# arguments are: corename configdir
+
+set -e
+
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE="${2:-}"
+if [[ -z "$CONFIG_SOURCE" ]]; then
+    DEFAULT_CONFIGS=(_default data_driven_schema_configs)
+    for config_dir in "${DEFAULT_CONFIGS[@]}"; do
+        config_dir="/opt/solr/server/solr/configsets/$config_dir"
+        if [ -d "$config_dir" ]; then
+           CONFIG_SOURCE="$config_dir"
+           break
+        fi
+    done
+    if [[ -z $CONFIG_SOURCE ]]; then
+        echo "Cannot find default config"
+        exit 1
+    fi
+fi
+
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r "$CONFIG_SOURCE/" "$coredir"
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi

--- a/5.5/centos/scripts/run-initdb
+++ b/5.5/centos/scripts/run-initdb
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    case "$f" in
+        *.sh)     echo "$0: running $f"; . "$f" ;;
+        *)        echo "$0: ignoring $f" ;;
+    esac
+    echo
+done < <(find /docker-entrypoint-initdb.d/ -mindepth 1 -type f | sort -n)

--- a/5.5/centos/scripts/solr-create
+++ b/5.5/centos/scripts/solr-create
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+
+set -euo pipefail
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with:" "${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with:" "${@:1}"
+    stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+exec solr -f

--- a/5.5/centos/scripts/solr-create
+++ b/5.5/centos/scripts/solr-create
@@ -45,7 +45,7 @@ else
 
     # See https://github.com/docker-solr/docker-solr/issues/27
     echo "Checking core"
-    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+    if ! wget -O - "http://localhost:${SOLR_PORT}/solr/admin/cores?action=STATUS" | grep -q instanceDir; then
       echo "Could not find any cores"
       exit 1
     fi

--- a/5.5/centos/scripts/solr-demo
+++ b/5.5/centos/scripts/solr-demo
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
+else
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE -commit no example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE -commit no example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE -commit yes example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+
+exec solr -f

--- a/5.5/centos/scripts/solr-foreground
+++ b/5.5/centos/scripts/solr-foreground
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+echo "Starting Solr $SOLR_VERSION"
+
+exec solr -f "$@"

--- a/5.5/centos/scripts/solr-precreate
+++ b/5.5/centos/scripts/solr-precreate
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+/opt/docker-solr/scripts/precreate-core "$@"
+
+exec solr -f

--- a/5.5/centos/scripts/start-local-solr
+++ b/5.5/centos/scripts/start-local-solr
@@ -1,0 +1,42 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
+
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
+        echo "Here is the log:"
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
+    fi
+    exit 1
+fi

--- a/5.5/centos/scripts/stop-local-solr
+++ b/5.5/centos/scripts/stop-local-solr
@@ -1,0 +1,11 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop

--- a/5.5/centos/scripts/wait-for-solr.sh
+++ b/5.5/centos/scripts/wait-for-solr.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [--max-attempts count] [--wait-seconds seconds] [--solr-url url]
+# Deprecated usage: wait-for-solr.sh [ max_attempts [ wait_seconds ] ]
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] [--solr-url url]"
+  exit 1
+}
+
+max_attempts=12
+wait_seconds=5
+solr_url=http://localhost:8983
+
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options]
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+  --solr-url url: URL for Solr server to check. Default: $solr_url
+EOM
+     exit 0
+     ;;
+   --solr-url)
+     solr_url="$2";
+     shift 2
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+  * )
+    # deprecated invocation, kept for backwards compatibility
+    max_attempts=$1;
+    wait_seconds=$2;
+    echo "WARNING: deprecated invocation. Use $SCRIPT [--max-attempts count] [--wait-seconds seconds]"
+    shift 2;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<$max_attempts || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "--max-attempts should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "--wait-seconds $wait_seconds: not a number"
+grep -q -E '^https?://' <<<$solr_url || usage "--solr-url $solr_url: not a URL"
+
+let attempts_left=$max_attempts
+while (( attempts_left > 0 )); do
+  if wget -q -O - "$solr_url" | grep -q -i solr; then
+    break
+  fi
+  let "attempts_left--"
+  if (( attempts_left == 0 )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  if (( attempts_left == 1 )); then
+    attempts=attempt
+  else
+    attempts=attempts
+  fi
+  echo "solr is not running yet on $solr_url. $attempts_left $attempts left"
+  sleep "$wait_seconds"
+done
+echo "solr is running on $solr_url"

--- a/5.5/centos/scripts/wait-for-solr.sh
+++ b/5.5/centos/scripts/wait-for-solr.sh
@@ -21,7 +21,7 @@ function usage {
 
 max_attempts=12
 wait_seconds=5
-solr_url=http://localhost:8983
+solr_url=http://localhost:${SOLR_PORT}
 
 while (( $# > 0 )); do
   case "$1" in

--- a/6.6/centos/Dockerfile
+++ b/6.6/centos/Dockerfile
@@ -1,0 +1,80 @@
+
+ARG   CENTOS_PARENT_IMAGE=centos:7
+FROM  centos:7
+LABEL maintainer="Martijn Koster <mak-docker@greenhills.co.uk>"
+
+# there is no ready made jdk centos image, so we install java ourselves
+ENV JAVA_HOME="/etc/alternatives/jre" \
+    JAVA_VERSION="1.8.0"
+
+# /dev/urandom is used as random source, which is prefectly safe
+# according to http://www.2uo.de/myths-about-urandom/
+RUN yum install -y \
+       java-${JAVA_VERSION}-openjdk  \
+       java-${JAVA_VERSION}-openjdk-devel \
+    && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/java/jre/lib/security/java.security
+
+# Override the solr download location with e.g.:
+#   docker build -t mine --build-arg SOLR_DOWNLOAD_SERVER=http://www-eu.apache.org/dist/lucene/solr .
+ARG SOLR_DOWNLOAD_SERVER
+
+RUN yum update -y && \
+  yum -y install lsof procps wget gpg && \
+  yum clean all && \
+  rm -rf /var/cache/yum/*
+
+ENV SOLR_USER="solr" \
+    SOLR_UID="8983" \
+    SOLR_GROUP="solr" \
+    SOLR_GID="8983" \
+    SOLR_PORT="8983" \
+    SOLR_VERSION="6.6.2" \
+    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/6.6.2/solr-6.6.2.tgz" \
+    SOLR_SHA256="a41594888a30394df8819c36ceee727dd2ed0a7cd18b41230648f1ef1a8b0cd2" \
+    SOLR_KEYS="2085660D9C1FCCACC4A479A3BF160FF14992A24C" \
+    PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH"
+
+RUN groupadd -r --gid $SOLR_GID $SOLR_GROUP && \
+  useradd -r --uid $SOLR_UID --gid $SOLR_GID $SOLR_USER
+
+RUN set -e; for key in $SOLR_KEYS; do \
+    found=''; \
+    for server in \
+      ha.pool.sks-keyservers.net \
+      hkp://keyserver.ubuntu.com:80 \
+      hkp://p80.pool.sks-keyservers.net:80 \
+      pgp.mit.edu \
+    ; do \
+      echo "  trying $server for $key"; \
+      gpg --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch $key from several disparate servers -- network issues?" && exit 1; \
+  done; \
+  exit 0
+
+RUN mkdir -p /opt/solr && \
+  echo "downloading $SOLR_URL" && \
+  wget -nv $SOLR_URL -O /opt/solr.tgz && \
+  echo "downloading $SOLR_URL.asc" && \
+  wget -nv $SOLR_URL.asc -O /opt/solr.tgz.asc && \
+  echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \
+  (>&2 ls -l /opt/solr.tgz /opt/solr.tgz.asc) && \
+  gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \
+  tar -C /opt/solr --extract --file /opt/solr.tgz --strip-components=1 && \
+  rm /opt/solr.tgz* && \
+  rm -Rf /opt/solr/docs/ && \
+  mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores /opt/solr/server/logs /docker-entrypoint-initdb.d /opt/docker-solr && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
+  sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
+  chown -R $SOLR_USER:$SOLR_GROUP /opt/solr
+
+COPY scripts /opt/docker-solr/scripts
+RUN chown -R $SOLR_USER:$SOLR_GROUP /opt/docker-solr
+
+EXPOSE ${SOLR_PORT}
+WORKDIR /opt/solr
+USER $SOLR_USER
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["solr-foreground"]

--- a/6.6/centos/scripts/docker-entrypoint.sh
+++ b/6.6/centos/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/6.6/centos/scripts/init-solr-home
+++ b/6.6/centos/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/6.6/centos/scripts/precreate-core
+++ b/6.6/centos/scripts/precreate-core
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Create a core on disk
+# arguments are: corename configdir
+
+set -e
+
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE="${2:-}"
+if [[ -z "$CONFIG_SOURCE" ]]; then
+    DEFAULT_CONFIGS=(_default data_driven_schema_configs)
+    for config_dir in "${DEFAULT_CONFIGS[@]}"; do
+        config_dir="/opt/solr/server/solr/configsets/$config_dir"
+        if [ -d "$config_dir" ]; then
+           CONFIG_SOURCE="$config_dir"
+           break
+        fi
+    done
+    if [[ -z $CONFIG_SOURCE ]]; then
+        echo "Cannot find default config"
+        exit 1
+    fi
+fi
+
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r "$CONFIG_SOURCE/" "$coredir"
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi

--- a/6.6/centos/scripts/run-initdb
+++ b/6.6/centos/scripts/run-initdb
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    case "$f" in
+        *.sh)     echo "$0: running $f"; . "$f" ;;
+        *)        echo "$0: ignoring $f" ;;
+    esac
+    echo
+done < <(find /docker-entrypoint-initdb.d/ -mindepth 1 -type f | sort -n)

--- a/6.6/centos/scripts/solr-create
+++ b/6.6/centos/scripts/solr-create
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+
+set -euo pipefail
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with:" "${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with:" "${@:1}"
+    stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+exec solr -f

--- a/6.6/centos/scripts/solr-create
+++ b/6.6/centos/scripts/solr-create
@@ -45,7 +45,7 @@ else
 
     # See https://github.com/docker-solr/docker-solr/issues/27
     echo "Checking core"
-    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+    if ! wget -O - "http://localhost:${SOLR_PORT}/solr/admin/cores?action=STATUS" | grep -q instanceDir; then
       echo "Could not find any cores"
       exit 1
     fi

--- a/6.6/centos/scripts/solr-demo
+++ b/6.6/centos/scripts/solr-demo
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
+else
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE -commit no example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE -commit no example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE -commit yes example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+
+exec solr -f

--- a/6.6/centos/scripts/solr-foreground
+++ b/6.6/centos/scripts/solr-foreground
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+echo "Starting Solr $SOLR_VERSION"
+
+exec solr -f "$@"

--- a/6.6/centos/scripts/solr-precreate
+++ b/6.6/centos/scripts/solr-precreate
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+/opt/docker-solr/scripts/precreate-core "$@"
+
+exec solr -f

--- a/6.6/centos/scripts/start-local-solr
+++ b/6.6/centos/scripts/start-local-solr
@@ -1,0 +1,42 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
+
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
+        echo "Here is the log:"
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
+    fi
+    exit 1
+fi

--- a/6.6/centos/scripts/stop-local-solr
+++ b/6.6/centos/scripts/stop-local-solr
@@ -1,0 +1,11 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop

--- a/6.6/centos/scripts/wait-for-solr.sh
+++ b/6.6/centos/scripts/wait-for-solr.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [--max-attempts count] [--wait-seconds seconds] [--solr-url url]
+# Deprecated usage: wait-for-solr.sh [ max_attempts [ wait_seconds ] ]
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] [--solr-url url]"
+  exit 1
+}
+
+max_attempts=12
+wait_seconds=5
+solr_url=http://localhost:8983
+
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options]
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+  --solr-url url: URL for Solr server to check. Default: $solr_url
+EOM
+     exit 0
+     ;;
+   --solr-url)
+     solr_url="$2";
+     shift 2
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+  * )
+    # deprecated invocation, kept for backwards compatibility
+    max_attempts=$1;
+    wait_seconds=$2;
+    echo "WARNING: deprecated invocation. Use $SCRIPT [--max-attempts count] [--wait-seconds seconds]"
+    shift 2;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<$max_attempts || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "--max-attempts should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "--wait-seconds $wait_seconds: not a number"
+grep -q -E '^https?://' <<<$solr_url || usage "--solr-url $solr_url: not a URL"
+
+let attempts_left=$max_attempts
+while (( attempts_left > 0 )); do
+  if wget -q -O - "$solr_url" | grep -q -i solr; then
+    break
+  fi
+  let "attempts_left--"
+  if (( attempts_left == 0 )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  if (( attempts_left == 1 )); then
+    attempts=attempt
+  else
+    attempts=attempts
+  fi
+  echo "solr is not running yet on $solr_url. $attempts_left $attempts left"
+  sleep "$wait_seconds"
+done
+echo "solr is running on $solr_url"

--- a/6.6/centos/scripts/wait-for-solr.sh
+++ b/6.6/centos/scripts/wait-for-solr.sh
@@ -21,7 +21,7 @@ function usage {
 
 max_attempts=12
 wait_seconds=5
-solr_url=http://localhost:8983
+solr_url=http://localhost:${SOLR_PORT}
 
 while (( $# > 0 )); do
   case "$1" in

--- a/7.1/centos/Dockerfile
+++ b/7.1/centos/Dockerfile
@@ -1,0 +1,80 @@
+
+ARG   CENTOS_PARENT_IMAGE=centos:7
+FROM  centos:7
+LABEL maintainer="Martijn Koster <mak-docker@greenhills.co.uk>"
+
+# there is no ready made jdk centos image, so we install java ourselves
+ENV JAVA_HOME="/etc/alternatives/jre" \
+    JAVA_VERSION="1.8.0"
+
+# /dev/urandom is used as random source, which is prefectly safe
+# according to http://www.2uo.de/myths-about-urandom/
+RUN yum install -y \
+       java-${JAVA_VERSION}-openjdk  \
+       java-${JAVA_VERSION}-openjdk-devel \
+    && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/java/jre/lib/security/java.security
+
+# Override the solr download location with e.g.:
+#   docker build -t mine --build-arg SOLR_DOWNLOAD_SERVER=http://www-eu.apache.org/dist/lucene/solr .
+ARG SOLR_DOWNLOAD_SERVER
+
+RUN yum update -y && \
+  yum -y install lsof procps wget gpg && \
+  yum clean all && \
+  rm -rf /var/cache/yum/*
+
+ENV SOLR_USER="solr" \
+    SOLR_UID="8983" \
+    SOLR_GROUP="solr" \
+    SOLR_GID="8983" \
+    SOLR_PORT="8983" \
+    SOLR_VERSION="7.1.0" \
+    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/7.1.0/solr-7.1.0.tgz" \
+    SOLR_SHA256="5cd25cc2634e47efbb529658d6ddd406a7cd1b211affa26563a28db2d80b8133" \
+    SOLR_KEYS="38D2EA16DDF5FC722EBC433FDC92616F177050F6" \
+    PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH"
+
+RUN groupadd -r --gid $SOLR_GID $SOLR_GROUP && \
+  useradd -r --uid $SOLR_UID --gid $SOLR_GID $SOLR_USER
+
+RUN set -e; for key in $SOLR_KEYS; do \
+    found=''; \
+    for server in \
+      ha.pool.sks-keyservers.net \
+      hkp://keyserver.ubuntu.com:80 \
+      hkp://p80.pool.sks-keyservers.net:80 \
+      pgp.mit.edu \
+    ; do \
+      echo "  trying $server for $key"; \
+      gpg --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch $key from several disparate servers -- network issues?" && exit 1; \
+  done; \
+  exit 0
+
+RUN mkdir -p /opt/solr && \
+  echo "downloading $SOLR_URL" && \
+  wget -nv $SOLR_URL -O /opt/solr.tgz && \
+  echo "downloading $SOLR_URL.asc" && \
+  wget -nv $SOLR_URL.asc -O /opt/solr.tgz.asc && \
+  echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \
+  (>&2 ls -l /opt/solr.tgz /opt/solr.tgz.asc) && \
+  gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \
+  tar -C /opt/solr --extract --file /opt/solr.tgz --strip-components=1 && \
+  rm /opt/solr.tgz* && \
+  rm -Rf /opt/solr/docs/ && \
+  mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores /opt/solr/server/logs /docker-entrypoint-initdb.d /opt/docker-solr && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
+  sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
+  chown -R $SOLR_USER:$SOLR_GROUP /opt/solr
+
+COPY scripts /opt/docker-solr/scripts
+RUN chown -R $SOLR_USER:$SOLR_GROUP /opt/docker-solr
+
+EXPOSE ${SOLR_PORT}
+WORKDIR /opt/solr
+USER $SOLR_USER
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["solr-foreground"]

--- a/7.1/centos/scripts/docker-entrypoint.sh
+++ b/7.1/centos/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/7.1/centos/scripts/init-solr-home
+++ b/7.1/centos/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/7.1/centos/scripts/precreate-core
+++ b/7.1/centos/scripts/precreate-core
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Create a core on disk
+# arguments are: corename configdir
+
+set -e
+
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE="${2:-}"
+if [[ -z "$CONFIG_SOURCE" ]]; then
+    DEFAULT_CONFIGS=(_default data_driven_schema_configs)
+    for config_dir in "${DEFAULT_CONFIGS[@]}"; do
+        config_dir="/opt/solr/server/solr/configsets/$config_dir"
+        if [ -d "$config_dir" ]; then
+           CONFIG_SOURCE="$config_dir"
+           break
+        fi
+    done
+    if [[ -z $CONFIG_SOURCE ]]; then
+        echo "Cannot find default config"
+        exit 1
+    fi
+fi
+
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r "$CONFIG_SOURCE/" "$coredir"
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi

--- a/7.1/centos/scripts/run-initdb
+++ b/7.1/centos/scripts/run-initdb
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    case "$f" in
+        *.sh)     echo "$0: running $f"; . "$f" ;;
+        *)        echo "$0: ignoring $f" ;;
+    esac
+    echo
+done < <(find /docker-entrypoint-initdb.d/ -mindepth 1 -type f | sort -n)

--- a/7.1/centos/scripts/solr-create
+++ b/7.1/centos/scripts/solr-create
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+
+set -euo pipefail
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with:" "${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with:" "${@:1}"
+    stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+exec solr -f

--- a/7.1/centos/scripts/solr-create
+++ b/7.1/centos/scripts/solr-create
@@ -45,7 +45,7 @@ else
 
     # See https://github.com/docker-solr/docker-solr/issues/27
     echo "Checking core"
-    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+    if ! wget -O - "http://localhost:${SOLR_PORT}/solr/admin/cores?action=STATUS" | grep -q instanceDir; then
       echo "Could not find any cores"
       exit 1
     fi

--- a/7.1/centos/scripts/solr-demo
+++ b/7.1/centos/scripts/solr-demo
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
+else
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE -commit no example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE -commit no example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE -commit yes example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+
+exec solr -f

--- a/7.1/centos/scripts/solr-foreground
+++ b/7.1/centos/scripts/solr-foreground
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+echo "Starting Solr $SOLR_VERSION"
+
+exec solr -f "$@"

--- a/7.1/centos/scripts/solr-precreate
+++ b/7.1/centos/scripts/solr-precreate
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+/opt/docker-solr/scripts/precreate-core "$@"
+
+exec solr -f

--- a/7.1/centos/scripts/start-local-solr
+++ b/7.1/centos/scripts/start-local-solr
@@ -1,0 +1,42 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
+
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
+        echo "Here is the log:"
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
+    fi
+    exit 1
+fi

--- a/7.1/centos/scripts/stop-local-solr
+++ b/7.1/centos/scripts/stop-local-solr
@@ -1,0 +1,11 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop

--- a/7.1/centos/scripts/wait-for-solr.sh
+++ b/7.1/centos/scripts/wait-for-solr.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [--max-attempts count] [--wait-seconds seconds] [--solr-url url]
+# Deprecated usage: wait-for-solr.sh [ max_attempts [ wait_seconds ] ]
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] [--solr-url url]"
+  exit 1
+}
+
+max_attempts=12
+wait_seconds=5
+solr_url=http://localhost:8983
+
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options]
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+  --solr-url url: URL for Solr server to check. Default: $solr_url
+EOM
+     exit 0
+     ;;
+   --solr-url)
+     solr_url="$2";
+     shift 2
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+  * )
+    # deprecated invocation, kept for backwards compatibility
+    max_attempts=$1;
+    wait_seconds=$2;
+    echo "WARNING: deprecated invocation. Use $SCRIPT [--max-attempts count] [--wait-seconds seconds]"
+    shift 2;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<$max_attempts || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "--max-attempts should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "--wait-seconds $wait_seconds: not a number"
+grep -q -E '^https?://' <<<$solr_url || usage "--solr-url $solr_url: not a URL"
+
+let attempts_left=$max_attempts
+while (( attempts_left > 0 )); do
+  if wget -q -O - "$solr_url" | grep -q -i solr; then
+    break
+  fi
+  let "attempts_left--"
+  if (( attempts_left == 0 )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  if (( attempts_left == 1 )); then
+    attempts=attempt
+  else
+    attempts=attempts
+  fi
+  echo "solr is not running yet on $solr_url. $attempts_left $attempts left"
+  sleep "$wait_seconds"
+done
+echo "solr is running on $solr_url"

--- a/7.1/centos/scripts/wait-for-solr.sh
+++ b/7.1/centos/scripts/wait-for-solr.sh
@@ -21,7 +21,7 @@ function usage {
 
 max_attempts=12
 wait_seconds=5
-solr_url=http://localhost:8983
+solr_url=http://localhost:${SOLR_PORT}
 
 while (( $# > 0 )); do
   case "$1" in

--- a/7.2/centos/Dockerfile
+++ b/7.2/centos/Dockerfile
@@ -1,0 +1,80 @@
+
+ARG   CENTOS_PARENT_IMAGE=centos:7
+FROM  centos:7
+LABEL maintainer="Martijn Koster <mak-docker@greenhills.co.uk>"
+
+# there is no ready made jdk centos image, so we install java ourselves
+ENV JAVA_HOME="/etc/alternatives/jre" \
+    JAVA_VERSION="1.8.0"
+
+# /dev/urandom is used as random source, which is prefectly safe
+# according to http://www.2uo.de/myths-about-urandom/
+RUN yum install -y \
+       java-${JAVA_VERSION}-openjdk  \
+       java-${JAVA_VERSION}-openjdk-devel \
+    && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/java/jre/lib/security/java.security
+
+# Override the solr download location with e.g.:
+#   docker build -t mine --build-arg SOLR_DOWNLOAD_SERVER=http://www-eu.apache.org/dist/lucene/solr .
+ARG SOLR_DOWNLOAD_SERVER
+
+RUN yum update -y && \
+  yum -y install lsof procps wget gpg && \
+  yum clean all && \
+  rm -rf /var/cache/yum/*
+
+ENV SOLR_USER="solr" \
+    SOLR_UID="8983" \
+    SOLR_GROUP="solr" \
+    SOLR_GID="8983" \
+    SOLR_PORT="8983" \
+    SOLR_VERSION="7.2.0" \
+    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/7.2.0/solr-7.2.0.tgz" \
+    SOLR_SHA256="1b2cedf176a62c259bfa72db5bf0ba18cc3af255bc8e25187d3b58213535011f" \
+    SOLR_KEYS="E6E21FFCDCEA14C95910EA65051A0FAF76BC6507" \
+    PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH"
+
+RUN groupadd -r --gid $SOLR_GID $SOLR_GROUP && \
+  useradd -r --uid $SOLR_UID --gid $SOLR_GID $SOLR_USER
+
+RUN set -e; for key in $SOLR_KEYS; do \
+    found=''; \
+    for server in \
+      ha.pool.sks-keyservers.net \
+      hkp://keyserver.ubuntu.com:80 \
+      hkp://p80.pool.sks-keyservers.net:80 \
+      pgp.mit.edu \
+    ; do \
+      echo "  trying $server for $key"; \
+      gpg --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch $key from several disparate servers -- network issues?" && exit 1; \
+  done; \
+  exit 0
+
+RUN mkdir -p /opt/solr && \
+  echo "downloading $SOLR_URL" && \
+  wget -nv $SOLR_URL -O /opt/solr.tgz && \
+  echo "downloading $SOLR_URL.asc" && \
+  wget -nv $SOLR_URL.asc -O /opt/solr.tgz.asc && \
+  echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \
+  (>&2 ls -l /opt/solr.tgz /opt/solr.tgz.asc) && \
+  gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \
+  tar -C /opt/solr --extract --file /opt/solr.tgz --strip-components=1 && \
+  rm /opt/solr.tgz* && \
+  rm -Rf /opt/solr/docs/ && \
+  mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores /opt/solr/server/logs /docker-entrypoint-initdb.d /opt/docker-solr && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
+  sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
+  chown -R $SOLR_USER:$SOLR_GROUP /opt/solr
+
+COPY scripts /opt/docker-solr/scripts
+RUN chown -R $SOLR_USER:$SOLR_GROUP /opt/docker-solr
+
+EXPOSE ${SOLR_PORT}
+WORKDIR /opt/solr
+USER $SOLR_USER
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["solr-foreground"]

--- a/7.2/centos/scripts/docker-entrypoint.sh
+++ b/7.2/centos/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" = '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/7.2/centos/scripts/init-solr-home
+++ b/7.2/centos/scripts/init-solr-home
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# A helper script to initialise a custom SOLR_HOME.
+# For example:
+#
+#    mkdir mysolrhome
+#    sudo chown 8983:8983 mysolrhome
+#    docker run -it -v $PWD/mysolrhome:/mysolrhome -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes solr
+#
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+# Normally SOLR_HOME is not set, and Solr will use /opt/solr/server/solr/
+# If it's not set, then this script has no relevance.
+if [[ -z $SOLR_HOME ]]; then
+    exit
+fi
+
+# require an explicit opt-in. Without this, you can use the SOLR_HOME and
+# volumes, and configure it from the command-line or a docker-entrypoint-initdb.d
+# script
+if [[ "$INIT_SOLR_HOME" != "yes" ]]; then
+  exit
+fi
+
+# check the directory exists.
+if [ ! -d "$SOLR_HOME" ]; then
+    echo "SOLR_HOME $SOLR_HOME does not exist"
+    exit 1
+fi
+
+# check for existing Solr
+if [ -f "$SOLR_HOME/solr.xml" ]; then
+   exit
+fi
+
+# refuse to use non-empty directories, which are likely a misconfiguration
+if [ "$(find "$SOLR_HOME" -mindepth  1 ! -name lost+found | wc -l)" != '0' ]; then
+    echo "SOLR_HOME directory $SOLR_HOME is not empty; refusing to create a solr home."
+    exit 1
+fi
+
+# populate with default solr home contents
+echo "copying solr home contents to $SOLR_HOME"
+cp -R /opt/solr/server/solr/*  "$SOLR_HOME"

--- a/7.2/centos/scripts/precreate-core
+++ b/7.2/centos/scripts/precreate-core
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Create a core on disk
+# arguments are: corename configdir
+
+set -e
+
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE="${2:-}"
+if [[ -z "$CONFIG_SOURCE" ]]; then
+    DEFAULT_CONFIGS=(_default data_driven_schema_configs)
+    for config_dir in "${DEFAULT_CONFIGS[@]}"; do
+        config_dir="/opt/solr/server/solr/configsets/$config_dir"
+        if [ -d "$config_dir" ]; then
+           CONFIG_SOURCE="$config_dir"
+           break
+        fi
+    done
+    if [[ -z $CONFIG_SOURCE ]]; then
+        echo "Cannot find default config"
+        exit 1
+    fi
+fi
+
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r "$CONFIG_SOURCE/" "$coredir"
+    touch "$coredir/core.properties"
+    echo created "$CORE"
+else
+    echo "core $CORE already exists"
+fi

--- a/7.2/centos/scripts/run-initdb
+++ b/7.2/centos/scripts/run-initdb
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# init script for handling a custom SOLR_HOME
+/opt/docker-solr/scripts/init-solr-home
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read f; do
+    case "$f" in
+        *.sh)     echo "$0: running $f"; . "$f" ;;
+        *)        echo "$0: ignoring $f" ;;
+    esac
+    echo
+done < <(find /docker-entrypoint-initdb.d/ -mindepth 1 -type f | sort -n)

--- a/7.2/centos/scripts/solr-create
+++ b/7.2/centos/scripts/solr-create
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+
+set -euo pipefail
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "could not determine core name"
+  exit 1
+fi
+
+# cores get created in SOLR_HOME
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "$CORE_DIR exists; skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with:" "${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with:" "${@:1}"
+    stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+exec solr -f

--- a/7.2/centos/scripts/solr-create
+++ b/7.2/centos/scripts/solr-create
@@ -45,7 +45,7 @@ else
 
     # See https://github.com/docker-solr/docker-solr/issues/27
     echo "Checking core"
-    if ! wget -O - 'http://localhost:8983/solr/admin/cores?action=STATUS' | grep -q instanceDir; then
+    if ! wget -O - "http://localhost:${SOLR_PORT}/solr/admin/cores?action=STATUS" | grep -q instanceDir; then
       echo "Could not find any cores"
       exit 1
     fi

--- a/7.2/centos/scripts/solr-demo
+++ b/7.2/centos/scripts/solr-demo
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=demo
+CORE_DIR="${SOLR_HOME:-/opt/solr/server/solr}/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
+else
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  /opt/solr/bin/post -c $CORE -commit no example/exampledocs/*.xml
+  /opt/solr/bin/post -c $CORE -commit no example/exampledocs/books.json
+  /opt/solr/bin/post -c $CORE -commit yes example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+
+exec solr -f

--- a/7.2/centos/scripts/solr-foreground
+++ b/7.2/centos/scripts/solr-foreground
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+echo "Starting Solr $SOLR_VERSION"
+
+exec solr -f "$@"

--- a/7.2/centos/scripts/solr-precreate
+++ b/7.2/centos/scripts/solr-precreate
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir mycores; chown 8983:8983 mycores
+#      docker run -it --rm -P -v $PWD/mycores:/opt/solr/server/solr/mycores solr solr-precreate mycore
+set -e
+
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+/opt/docker-solr/scripts/precreate-core "$@"
+
+exec solr -f

--- a/7.2/centos/scripts/start-local-solr
+++ b/7.2/centos/scripts/start-local-solr
@@ -1,0 +1,42 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+# determine the solr logs dir, set by SOLR_LOGS_DIR in the environment or in solr.in.sh.
+# let bash parse it, then prefix MY_ so we don't polute the environment used by Solr.
+MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
+eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | egrep '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
+
+MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+
+if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
+    echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"
+    exit 1
+fi
+
+# If the SOLR_PID_DIR is specified by the user, let Solr use that
+if [ -z "${MY_SOLR_PID_DIR:-}" ]; then
+    # if not, and the default location is not writable, put it in the log dir
+    if [ ! -w "${MY_SOLR_PID_DIR:-/opt/solr/bin}" ]; then
+        export SOLR_PID_DIR="$MY_SOLR_LOGS_DIR"
+    fi
+fi
+
+echo "Running solr in the background. Logs are in $MY_SOLR_LOGS_DIR"
+SOLR_OPTS=$MY_SOLR_OPTS solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f "$MY_SOLR_LOGS_DIR/solr.log" ]; then
+        echo "Here is the log:"
+        cat "$MY_SOLR_LOGS_DIR/solr.log"
+    fi
+    exit 1
+fi

--- a/7.2/centos/scripts/stop-local-solr
+++ b/7.2/centos/scripts/stop-local-solr
@@ -1,0 +1,11 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop

--- a/7.2/centos/scripts/wait-for-solr.sh
+++ b/7.2/centos/scripts/wait-for-solr.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [--max-attempts count] [--wait-seconds seconds] [--solr-url url]
+# Deprecated usage: wait-for-solr.sh [ max_attempts [ wait_seconds ] ]
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" = "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] [--solr-url url]"
+  exit 1
+}
+
+max_attempts=12
+wait_seconds=5
+solr_url=http://localhost:8983
+
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options]
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+  --solr-url url: URL for Solr server to check. Default: $solr_url
+EOM
+     exit 0
+     ;;
+   --solr-url)
+     solr_url="$2";
+     shift 2
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+  * )
+    # deprecated invocation, kept for backwards compatibility
+    max_attempts=$1;
+    wait_seconds=$2;
+    echo "WARNING: deprecated invocation. Use $SCRIPT [--max-attempts count] [--wait-seconds seconds]"
+    shift 2;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<$max_attempts || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "--max-attempts should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<$wait_seconds || usage "--wait-seconds $wait_seconds: not a number"
+grep -q -E '^https?://' <<<$solr_url || usage "--solr-url $solr_url: not a URL"
+
+let attempts_left=$max_attempts
+while (( attempts_left > 0 )); do
+  if wget -q -O - "$solr_url" | grep -q -i solr; then
+    break
+  fi
+  let "attempts_left--"
+  if (( attempts_left == 0 )); then
+    echo "solr is still not running; giving up"
+    exit 1
+  fi
+  if (( attempts_left == 1 )); then
+    attempts=attempt
+  else
+    attempts=attempts
+  fi
+  echo "solr is not running yet on $solr_url. $attempts_left $attempts left"
+  sleep "$wait_seconds"
+done
+echo "solr is running on $solr_url"

--- a/7.2/centos/scripts/wait-for-solr.sh
+++ b/7.2/centos/scripts/wait-for-solr.sh
@@ -21,7 +21,7 @@ function usage {
 
 max_attempts=12
 wait_seconds=5
-solr_url=http://localhost:8983
+solr_url=http://localhost:${SOLR_PORT}
 
 while (( $# > 0 )); do
   case "$1" in

--- a/Dockerfile-centos.template
+++ b/Dockerfile-centos.template
@@ -1,0 +1,80 @@
+
+ARG   CENTOS_PARENT_IMAGE=centos:7
+FROM  centos:7
+LABEL maintainer="Martijn Koster <mak-docker@greenhills.co.uk>"
+
+# there is no ready made jdk centos image, so we install java ourselves
+ENV JAVA_HOME="/etc/alternatives/jre" \
+    JAVA_VERSION="1.8.0"
+
+# /dev/urandom is used as random source, which is prefectly safe
+# according to http://www.2uo.de/myths-about-urandom/
+RUN yum install -y \
+       java-${JAVA_VERSION}-openjdk  \
+       java-${JAVA_VERSION}-openjdk-devel \
+    && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/java/jre/lib/security/java.security
+
+# Override the solr download location with e.g.:
+#   docker build -t mine --build-arg SOLR_DOWNLOAD_SERVER=http://www-eu.apache.org/dist/lucene/solr .
+ARG SOLR_DOWNLOAD_SERVER
+
+RUN yum update -y && \
+  yum -y install lsof procps wget gpg && \
+  yum clean all && \
+  rm -rf /var/cache/yum/*
+
+ENV SOLR_USER="solr" \
+    SOLR_UID="8983" \
+    SOLR_GROUP="solr" \
+    SOLR_GID="8983" \
+    SOLR_PORT="8983" \
+    SOLR_VERSION="$REPLACE_SOLR_VERSION" \
+    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/$REPLACE_SOLR_VERSION/solr-$REPLACE_SOLR_VERSION.tgz" \
+    SOLR_SHA256="$REPLACE_SOLR_SHA256" \
+    SOLR_KEYS="$REPLACE_SOLR_KEYS" \
+    PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH"
+
+RUN groupadd -r --gid $SOLR_GID $SOLR_GROUP && \
+  useradd -r --uid $SOLR_UID --gid $SOLR_GID $SOLR_USER
+
+RUN set -e; for key in $SOLR_KEYS; do \
+    found=''; \
+    for server in \
+      ha.pool.sks-keyservers.net \
+      hkp://keyserver.ubuntu.com:80 \
+      hkp://p80.pool.sks-keyservers.net:80 \
+      pgp.mit.edu \
+    ; do \
+      echo "  trying $server for $key"; \
+      gpg --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch $key from several disparate servers -- network issues?" && exit 1; \
+  done; \
+  exit 0
+
+RUN mkdir -p /opt/solr && \
+  echo "downloading $SOLR_URL" && \
+  wget -nv $SOLR_URL -O /opt/solr.tgz && \
+  echo "downloading $SOLR_URL.asc" && \
+  wget -nv $SOLR_URL.asc -O /opt/solr.tgz.asc && \
+  echo "$SOLR_SHA256 */opt/solr.tgz" | sha256sum -c - && \
+  (>&2 ls -l /opt/solr.tgz /opt/solr.tgz.asc) && \
+  gpg --batch --verify /opt/solr.tgz.asc /opt/solr.tgz && \
+  tar -C /opt/solr --extract --file /opt/solr.tgz --strip-components=1 && \
+  rm /opt/solr.tgz* && \
+  rm -Rf /opt/solr/docs/ && \
+  mkdir -p /opt/solr/server/solr/lib /opt/solr/server/solr/mycores /opt/solr/server/logs /docker-entrypoint-initdb.d /opt/docker-solr && \
+  sed -i -e 's/"\$(whoami)" == "root"/$(id -u) == 0/' /opt/solr/bin/solr && \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr && \
+  sed -i -e '/-Dsolr.clustering.enabled=true/ a SOLR_OPTS="$SOLR_OPTS -Dsun.net.inetaddr.ttl=60 -Dsun.net.inetaddr.negative.ttl=60"' /opt/solr/bin/solr.in.sh && \
+  chown -R $SOLR_USER:$SOLR_GROUP /opt/solr
+
+COPY scripts /opt/docker-solr/scripts
+RUN chown -R $SOLR_USER:$SOLR_GROUP /opt/docker-solr
+
+EXPOSE $SOLR_PORT
+WORKDIR /opt/solr
+USER $SOLR_USER
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["solr-foreground"]

--- a/TAGS
+++ b/TAGS
@@ -1,12 +1,16 @@
 5.5:5.5.5:5.5 5
 5.5/alpine:5.5.5-alpine:5.5-alpine 5-alpine
 5.5/slim:5.5.5-slim:5.5-slim 5-slim
+5.5/centos:5.5.5-centos:5.5-centos 5-centos
 6.6:6.6.2:6.6 6
 6.6/alpine:6.6.2-alpine:6.6-alpine 6-alpine
 6.6/slim:6.6.2-slim:6.6-slim 6-slim
+6.6/centos:6.6.2-centos:6.6-centos 6-centos
 7.1:7.1.0:7.1
 7.1/alpine:7.1.0-alpine:7.1-alpine
 7.1/slim:7.1.0-slim:7.1-slim
+7.1/centos:7.1.0-centos:7.1-centos
 7.2:7.2.0:7.2 7 latest
 7.2/alpine:7.2.0-alpine:7.2-alpine 7-alpine latest-alpine
 7.2/slim:7.2.0-slim:7.2-slim 7-slim latest-slim
+7.2/centos:7.2.0-centos:7.2-centos 7-centos latest-centos

--- a/tests/version/test.sh
+++ b/tests/version/test.sh
@@ -35,6 +35,14 @@ if echo "$tag" | grep -q -- -alpine; then
     exit 1
   fi
   echo "Alpine $alpine_version"
+elif echo "$tag" | grep -q -- -centos; then
+  centos_version=$(docker exec --user=solr "$container_name" cat /etc/centos-release || true)
+  if [[ -z $centos_version ]]; then
+    echo "Could not get centos version from container $container_name"
+    container_cleanup "$container_name"
+    exit 1
+  fi
+  echo "CentOS $centos_version"
 else
   debian_version=$(docker exec --user=solr "$container_name" cat /etc/debian_version || true)
   if [[ -z $debian_version ]]; then

--- a/tools/update.sh
+++ b/tools/update.sh
@@ -281,6 +281,7 @@ for version in "${versions[@]}"; do
     write_files "$full_version"
     write_files "$full_version" 'alpine'
     write_files "$full_version" 'slim'
+    write_files "$full_version" 'centos'
     echo
 done
 


### PR DESCRIPTION
In addition to `alpine`, `slim` and `debian` based distros this adds a `centos` based Docker-Solr image. This adds a new template and adjusts tests to handle centos distros as well.

As there is no ready made openjdk-centos image, a recent jdk is installed in this Dockerfile. Moreover the Java version can be specified via environment variable. Also the centos base image can be changed as Docker build argument. This can be handy, if you need a specific centos based image that uses the `yum` package manager.

I'm not sure if I missed a spot to adjust, but [Travis is ok with it](https://www.travis-ci.org/shopping24/docker-solr/builds/325456672).
