### PR TITLE
Allow persistence storage in orchestrators

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,4 +1,3 @@
-
 FROM openjdk:9-jre
 MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 
@@ -7,7 +6,11 @@ MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 ARG SOLR_DOWNLOAD_SERVER
 
 RUN apt-get update && \
-  apt-get -y install lsof procps wget gpg && \
+  apt-get -y install lsof \
+  procps \
+  wget \
+  sudo \
+  gpg && \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \
@@ -76,7 +79,6 @@ RUN chown -R $SOLR_USER:$SOLR_GROUP /opt/docker-solr
 
 EXPOSE 8983
 WORKDIR /opt/solr
-USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["solr-foreground"]

--- a/7.3/scripts/docker-entrypoint.sh
+++ b/7.3/scripts/docker-entrypoint.sh
@@ -18,10 +18,14 @@ if [ "${1:0:1}" = '-' ]; then
     set -- solr-foreground "$@"
 fi
 
+# Ensure that SOLR_HOME exists and Solr has RW access
+mkdir -p $SOLR_HOME
+chown $SOLR_USER:$SOLR_GROUP $SOLR_HOME
+
 # execute command passed in as arguments.
 # The Dockerfile has specified the PATH to include
 # /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
 # like solr-foreground, solr-create, solr-precreate, solr-demo).
 # Note: if you specify "solr", you'll typically want to add -f to run it in
 # the foreground.
-exec "$@"
+exec sudo -E PATH=$PATH -u $SOLR_USER bash -c "$@"


### PR DESCRIPTION
- Ensured that the SOLR_HOME directory is writable when it is mounted as a volume
Closes #175 
