### PR TITLE
Add Solr 6.6.5

### DIFF
--- a/6.6/Dockerfile
+++ b/6.6/Dockerfile
@@ -14,9 +14,9 @@ ENV SOLR_USER="solr" \
     SOLR_UID="8983" \
     SOLR_GROUP="solr" \
     SOLR_GID="8983" \
-    SOLR_VERSION="6.6.4" \
-    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/6.6.4/solr-6.6.4.tgz" \
-    SOLR_SHA256="cb4a8552c3b60a7a195280e8bcd65ba2c045488fa52778f620138543c5265c50" \
+    SOLR_VERSION="6.6.5" \
+    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/6.6.5/solr-6.6.5.tgz" \
+    SOLR_SHA256="fa65e922bc32d36ef65bee866095da563aa5ddd7e953798c06b6494572d51729" \
     SOLR_KEYS="2085660D9C1FCCACC4A479A3BF160FF14992A24C" \
     PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH"
 

--- a/6.6/alpine/Dockerfile
+++ b/6.6/alpine/Dockerfile
@@ -19,9 +19,9 @@ ENV SOLR_USER="solr" \
     SOLR_UID="8983" \
     SOLR_GROUP="solr" \
     SOLR_GID="8983" \
-    SOLR_VERSION="6.6.4" \
-    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/6.6.4/solr-6.6.4.tgz" \
-    SOLR_SHA256="cb4a8552c3b60a7a195280e8bcd65ba2c045488fa52778f620138543c5265c50" \
+    SOLR_VERSION="6.6.5" \
+    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/6.6.5/solr-6.6.5.tgz" \
+    SOLR_SHA256="fa65e922bc32d36ef65bee866095da563aa5ddd7e953798c06b6494572d51729" \
     SOLR_KEYS="2085660D9C1FCCACC4A479A3BF160FF14992A24C" \
     PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH"
 

--- a/6.6/slim/Dockerfile
+++ b/6.6/slim/Dockerfile
@@ -14,9 +14,9 @@ ENV SOLR_USER="solr" \
     SOLR_UID="8983" \
     SOLR_GROUP="solr" \
     SOLR_GID="8983" \
-    SOLR_VERSION="6.6.4" \
-    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/6.6.4/solr-6.6.4.tgz" \
-    SOLR_SHA256="cb4a8552c3b60a7a195280e8bcd65ba2c045488fa52778f620138543c5265c50" \
+    SOLR_VERSION="6.6.5" \
+    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/6.6.5/solr-6.6.5.tgz" \
+    SOLR_SHA256="fa65e922bc32d36ef65bee866095da563aa5ddd7e953798c06b6494572d51729" \
     SOLR_KEYS="2085660D9C1FCCACC4A479A3BF160FF14992A24C" \
     PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH"
 

--- a/TAGS
+++ b/TAGS
@@ -1,9 +1,9 @@
 5.5:5.5.5:5.5 5
 5.5/alpine:5.5.5-alpine:5.5-alpine 5-alpine
 5.5/slim:5.5.5-slim:5.5-slim 5-slim
-6.6:6.6.4:6.6 6
-6.6/alpine:6.6.4-alpine:6.6-alpine 6-alpine
-6.6/slim:6.6.4-slim:6.6-slim 6-slim
+6.6:6.6.5:6.6 6
+6.6/alpine:6.6.5-alpine:6.6-alpine 6-alpine
+6.6/slim:6.6.5-slim:6.6-slim 6-slim
 7.1:7.1.0:7.1
 7.1/alpine:7.1.0-alpine:7.1-alpine
 7.1/slim:7.1.0-slim:7.1-slim


### PR DESCRIPTION
As stated in the issue #184 was a security release, so here is an PR that adds solr 6.6.5.
I basically run the commands as described in builder/README.txt and removed changes to 7.4. 