### PR TITLE
Add optional build arg ADD_JDBC_PSQL_DRIVER to auto download postgreSQL Driver

### DIFF
--- a/7.5/Dockerfile
+++ b/7.5/Dockerfile
@@ -6,6 +6,10 @@ MAINTAINER  Martijn Koster "mak-docker@greenhills.co.uk"
 #   docker build -t mine --build-arg SOLR_DOWNLOAD_SERVER=http://www-eu.apache.org/dist/lucene/solr .
 ARG SOLR_DOWNLOAD_SERVER
 
+ARG ADD_JDBC_PSQL_DRIVER
+
+ENV JDBC_PSQL_VERSION 42.2.5
+
 RUN apt-get update && \
   apt-get -y install lsof procps wget gpg && \
   rm -rf /var/lib/apt/lists/*
@@ -73,6 +77,9 @@ RUN set -e; \
 
 COPY scripts /opt/docker-solr/scripts
 RUN chown -R $SOLR_USER:$SOLR_GROUP /opt/docker-solr
+
+RUN [ ! -z "$ADD_JDBC_PSQL_DRIVER" ] \
+    && wget -O /opt/solr/dist/postgresql-$JDBC_PSQL_VERSION.jar "http://jdbc.postgresql.org/download/postgresql-$JDBC_PSQL_VERSION.jar"
 
 EXPOSE 8983
 WORKDIR /opt/solr

--- a/7.5/Dockerfile
+++ b/7.5/Dockerfile
@@ -79,7 +79,8 @@ COPY scripts /opt/docker-solr/scripts
 RUN chown -R $SOLR_USER:$SOLR_GROUP /opt/docker-solr
 
 RUN [ ! -z "$ADD_JDBC_PSQL_DRIVER" ] \
-    && wget -O /opt/solr/dist/postgresql-$JDBC_PSQL_VERSION.jar "http://jdbc.postgresql.org/download/postgresql-$JDBC_PSQL_VERSION.jar"
+    && mkdir /opt/solr/contrib/dataimporthandler/lib \
+    && wget -O /opt/solr/contrib/dataimporthandler/lib/postgresql-$JDBC_PSQL_VERSION.jar "http://jdbc.postgresql.org/download/postgresql-$JDBC_PSQL_VERSION.jar"
 
 EXPOSE 8983
 WORKDIR /opt/solr


### PR DESCRIPTION
`docker build -t my_solr . --build-arg ADD_JDBC_PSQL_DRIVER=1` builds solr with jdbc.postgresql.org driver