### PR TITLE
Fix Alpine error when building for ARM64 (AArch64)

### DIFF
--- a/5.5/alpine/Dockerfile
+++ b/5.5/alpine/Dockerfile
@@ -52,7 +52,7 @@ RUN set -e; \
 
 RUN set -e; \
   export GNUPGHOME="/tmp/gnupg_home" && \
-  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/')"; \
+  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"; \
   wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch"; \
   wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch.asc"; \
   gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \

--- a/6.6/alpine/Dockerfile
+++ b/6.6/alpine/Dockerfile
@@ -52,7 +52,7 @@ RUN set -e; \
 
 RUN set -e; \
   export GNUPGHOME="/tmp/gnupg_home" && \
-  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/')"; \
+  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"; \
   wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch"; \
   wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch.asc"; \
   gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \

--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -52,7 +52,7 @@ RUN set -e; \
 
 RUN set -e; \
   export GNUPGHOME="/tmp/gnupg_home" && \
-  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/')"; \
+  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"; \
   wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch"; \
   wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch.asc"; \
   gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -52,7 +52,7 @@ RUN set -e; \
 
 RUN set -e; \
   export GNUPGHOME="/tmp/gnupg_home" && \
-  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/')"; \
+  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"; \
   wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch"; \
   wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch.asc"; \
   gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \

--- a/7.3/alpine/Dockerfile
+++ b/7.3/alpine/Dockerfile
@@ -52,7 +52,7 @@ RUN set -e; \
 
 RUN set -e; \
   export GNUPGHOME="/tmp/gnupg_home" && \
-  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/')"; \
+  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"; \
   wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch"; \
   wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch.asc"; \
   gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \

--- a/7.4/alpine/Dockerfile
+++ b/7.4/alpine/Dockerfile
@@ -52,7 +52,7 @@ RUN set -e; \
 
 RUN set -e; \
   export GNUPGHOME="/tmp/gnupg_home" && \
-  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/')"; \
+  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"; \
   wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch"; \
   wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch.asc"; \
   gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \

--- a/7.5/alpine/Dockerfile
+++ b/7.5/alpine/Dockerfile
@@ -52,7 +52,7 @@ RUN set -e; \
 
 RUN set -e; \
   export GNUPGHOME="/tmp/gnupg_home" && \
-  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/')"; \
+  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"; \
   wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch"; \
   wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch.asc"; \
   gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -52,7 +52,7 @@ RUN set -e; \
 
 RUN set -e; \
   export GNUPGHOME="/tmp/gnupg_home" && \
-  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/')"; \
+  apkArch="$(apk --print-arch | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"; \
   wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch"; \
   wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$apkArch.asc"; \
   gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \


### PR DESCRIPTION
[This PR fixes #190]

On Alpine based platforms `apk --print-arch` prints out `x86_64` for `AMD64` architectures
and `aarch64` for `ARM64` architectures.  This is not the expected behaviour for most
projects (including GOSU).

After this change, it is possible to pull the expected release of GOSU from Tianon's repository.

Signed-off-by: Lee Jones <lee.jones@linaro.org>