### PR TITLE
Solr 8.3, Java 13, wait-for-zookeeper.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,14 @@ jobs:
   include:
     - stage: build, test, deploy
       env:
+      - PROCESS=8.3/slim
+      script: tools/build_test_push.sh 8.3/slim
+    - stage: build, test, deploy
+      env:
+      - PROCESS=8.3
+      script: tools/build_test_push.sh 8.3
+    - stage: build, test, deploy
+      env:
       - PROCESS=8.2/slim
       script: tools/build_test_push.sh 8.2/slim
     - stage: build, test, deploy

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/5.5/scripts/wait-for-zookeeper.sh
+++ b/5.5/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    if ! echo srvr | nc "$host" 2181 > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup:-}" ]; then
+  lookup=solr-zookeeper-headless
+fi
+
+echo "Looking up '$lookup'"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if getent hosts "$lookup" > $TMP_HOSTS; then
+    while read -r ip host ; do
+      check_zookeeper "$ip"
+    done <$TMP_HOSTS
+  else
+    echo "Cannot find $lookup yet"
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done

--- a/5.5/slim/Dockerfile
+++ b/5.5/slim/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/5.5/slim/scripts/wait-for-zookeeper.sh
+++ b/5.5/slim/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    if ! echo srvr | nc "$host" 2181 > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup:-}" ]; then
+  lookup=solr-zookeeper-headless
+fi
+
+echo "Looking up '$lookup'"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if getent hosts "$lookup" > $TMP_HOSTS; then
+    while read -r ip host ; do
+      check_zookeeper "$ip"
+    done <$TMP_HOSTS
+  else
+    echo "Cannot find $lookup yet"
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done

--- a/6.6/Dockerfile
+++ b/6.6/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/6.6/scripts/wait-for-zookeeper.sh
+++ b/6.6/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    if ! echo srvr | nc "$host" 2181 > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup:-}" ]; then
+  lookup=solr-zookeeper-headless
+fi
+
+echo "Looking up '$lookup'"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if getent hosts "$lookup" > $TMP_HOSTS; then
+    while read -r ip host ; do
+      check_zookeeper "$ip"
+    done <$TMP_HOSTS
+  else
+    echo "Cannot find $lookup yet"
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done

--- a/6.6/slim/Dockerfile
+++ b/6.6/slim/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/6.6/slim/scripts/wait-for-zookeeper.sh
+++ b/6.6/slim/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    if ! echo srvr | nc "$host" 2181 > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup:-}" ]; then
+  lookup=solr-zookeeper-headless
+fi
+
+echo "Looking up '$lookup'"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if getent hosts "$lookup" > $TMP_HOSTS; then
+    while read -r ip host ; do
+      check_zookeeper "$ip"
+    done <$TMP_HOSTS
+  else
+    echo "Cannot find $lookup yet"
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done

--- a/7.5/Dockerfile
+++ b/7.5/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/7.5/scripts/wait-for-zookeeper.sh
+++ b/7.5/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    if ! echo srvr | nc "$host" 2181 > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup:-}" ]; then
+  lookup=solr-zookeeper-headless
+fi
+
+echo "Looking up '$lookup'"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if getent hosts "$lookup" > $TMP_HOSTS; then
+    while read -r ip host ; do
+      check_zookeeper "$ip"
+    done <$TMP_HOSTS
+  else
+    echo "Cannot find $lookup yet"
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done

--- a/7.5/slim/Dockerfile
+++ b/7.5/slim/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/7.5/slim/scripts/wait-for-zookeeper.sh
+++ b/7.5/slim/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    if ! echo srvr | nc "$host" 2181 > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup:-}" ]; then
+  lookup=solr-zookeeper-headless
+fi
+
+echo "Looking up '$lookup'"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if getent hosts "$lookup" > $TMP_HOSTS; then
+    while read -r ip host ; do
+      check_zookeeper "$ip"
+    done <$TMP_HOSTS
+  else
+    echo "Cannot find $lookup yet"
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done

--- a/7.6/Dockerfile
+++ b/7.6/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/7.6/scripts/wait-for-zookeeper.sh
+++ b/7.6/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    if ! echo srvr | nc "$host" 2181 > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup:-}" ]; then
+  lookup=solr-zookeeper-headless
+fi
+
+echo "Looking up '$lookup'"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if getent hosts "$lookup" > $TMP_HOSTS; then
+    while read -r ip host ; do
+      check_zookeeper "$ip"
+    done <$TMP_HOSTS
+  else
+    echo "Cannot find $lookup yet"
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done

--- a/7.6/slim/Dockerfile
+++ b/7.6/slim/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/7.6/slim/scripts/wait-for-zookeeper.sh
+++ b/7.6/slim/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    if ! echo srvr | nc "$host" 2181 > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup:-}" ]; then
+  lookup=solr-zookeeper-headless
+fi
+
+echo "Looking up '$lookup'"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if getent hosts "$lookup" > $TMP_HOSTS; then
+    while read -r ip host ; do
+      check_zookeeper "$ip"
+    done <$TMP_HOSTS
+  else
+    echo "Cannot find $lookup yet"
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done

--- a/7.7/Dockerfile
+++ b/7.7/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/7.7/scripts/wait-for-zookeeper.sh
+++ b/7.7/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    if ! echo srvr | nc "$host" 2181 > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup:-}" ]; then
+  lookup=solr-zookeeper-headless
+fi
+
+echo "Looking up '$lookup'"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if getent hosts "$lookup" > $TMP_HOSTS; then
+    while read -r ip host ; do
+      check_zookeeper "$ip"
+    done <$TMP_HOSTS
+  else
+    echo "Cannot find $lookup yet"
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done

--- a/7.7/slim/Dockerfile
+++ b/7.7/slim/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/7.7/slim/scripts/wait-for-zookeeper.sh
+++ b/7.7/slim/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    if ! echo srvr | nc "$host" 2181 > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup:-}" ]; then
+  lookup=solr-zookeeper-headless
+fi
+
+echo "Looking up '$lookup'"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if getent hosts "$lookup" > $TMP_HOSTS; then
+    while read -r ip host ; do
+      check_zookeeper "$ip"
+    done <$TMP_HOSTS
+  else
+    echo "Cannot find $lookup yet"
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/8.0/scripts/wait-for-zookeeper.sh
+++ b/8.0/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+#
+# If no argument is provided, but a Solr-style ZK_HOST is set,
+# that will be used. If neither is provided, the default
+# name is 'solr-zookeeper-headless', to match the helm chart.
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    local port="${2:-2181}"
+    if ! echo srvr | nc "$host" "$port" > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup_arg:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup_arg=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup_arg:-}" ]; then
+  if [ -n "$ZK_HOST" ]; then
+    lookup_arg="$ZK_HOST"
+  else
+    lookup_arg=solr-zookeeper-headless
+  fi
+fi
+
+echo "Looking up '$lookup_arg'"
+# split on commas, for when a ZK_HOST string like zoo1:2181,zoo2:2181 is used
+IFS=',' read -ra lookups <<< "$lookup_arg"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  for lookup in "${lookups[@]}"; do
+    if grep -q -E "^\[[0-9].*\]" <<<"$lookup"; then
+      # looks like an IPv6 address, eg [2001:DB8::1] or [2001:DB8::1]:2181
+      # getent does not support the bracket notation, but does support IPv6 addresses
+      host=$(sed -E 's/\[(.*)\].*/\1/' <<<"$lookup")
+      port=$(sed -E 's/^\[(.*)\]:?//' <<<"$lookup")
+    else
+      # IPv4, just split on :
+      IFS=: read -ra split <<<"$lookup"
+      host="${split[0]}"
+      port="${split[1]:-}"
+    fi
+    if [[ "${VERBOSE:-}" == "yes" ]]; then
+      echo "Parsed host=$host port=${port:-}"
+    fi
+    if getent hosts "$host" > $TMP_HOSTS; then
+      while read -r ip hostname ; do
+        echo "${hostname:-}">/dev/null # consume for shellcheck
+        check_zookeeper "$ip" "$port"
+      done <$TMP_HOSTS
+    else
+      echo "Cannot find $lookup yet"
+    fi
+  done
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done
+
+# To test the parsing:
+#  bash scripts/wait-for-zookeeper.sh foo
+#  bash scripts/wait-for-zookeeper.sh 'ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2'
+#  ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2 bash scripts/wait-for-zookeeper.sh

--- a/8.0/slim/Dockerfile
+++ b/8.0/slim/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/8.0/slim/scripts/wait-for-zookeeper.sh
+++ b/8.0/slim/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+#
+# If no argument is provided, but a Solr-style ZK_HOST is set,
+# that will be used. If neither is provided, the default
+# name is 'solr-zookeeper-headless', to match the helm chart.
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    local port="${2:-2181}"
+    if ! echo srvr | nc "$host" "$port" > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup_arg:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup_arg=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup_arg:-}" ]; then
+  if [ -n "$ZK_HOST" ]; then
+    lookup_arg="$ZK_HOST"
+  else
+    lookup_arg=solr-zookeeper-headless
+  fi
+fi
+
+echo "Looking up '$lookup_arg'"
+# split on commas, for when a ZK_HOST string like zoo1:2181,zoo2:2181 is used
+IFS=',' read -ra lookups <<< "$lookup_arg"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  for lookup in "${lookups[@]}"; do
+    if grep -q -E "^\[[0-9].*\]" <<<"$lookup"; then
+      # looks like an IPv6 address, eg [2001:DB8::1] or [2001:DB8::1]:2181
+      # getent does not support the bracket notation, but does support IPv6 addresses
+      host=$(sed -E 's/\[(.*)\].*/\1/' <<<"$lookup")
+      port=$(sed -E 's/^\[(.*)\]:?//' <<<"$lookup")
+    else
+      # IPv4, just split on :
+      IFS=: read -ra split <<<"$lookup"
+      host="${split[0]}"
+      port="${split[1]:-}"
+    fi
+    if [[ "${VERBOSE:-}" == "yes" ]]; then
+      echo "Parsed host=$host port=${port:-}"
+    fi
+    if getent hosts "$host" > $TMP_HOSTS; then
+      while read -r ip hostname ; do
+        echo "${hostname:-}">/dev/null # consume for shellcheck
+        check_zookeeper "$ip" "$port"
+      done <$TMP_HOSTS
+    else
+      echo "Cannot find $lookup yet"
+    fi
+  done
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done
+
+# To test the parsing:
+#  bash scripts/wait-for-zookeeper.sh foo
+#  bash scripts/wait-for-zookeeper.sh 'ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2'
+#  ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2 bash scripts/wait-for-zookeeper.sh

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/8.1/scripts/wait-for-zookeeper.sh
+++ b/8.1/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+#
+# If no argument is provided, but a Solr-style ZK_HOST is set,
+# that will be used. If neither is provided, the default
+# name is 'solr-zookeeper-headless', to match the helm chart.
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    local port="${2:-2181}"
+    if ! echo srvr | nc "$host" "$port" > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup_arg:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup_arg=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup_arg:-}" ]; then
+  if [ -n "$ZK_HOST" ]; then
+    lookup_arg="$ZK_HOST"
+  else
+    lookup_arg=solr-zookeeper-headless
+  fi
+fi
+
+echo "Looking up '$lookup_arg'"
+# split on commas, for when a ZK_HOST string like zoo1:2181,zoo2:2181 is used
+IFS=',' read -ra lookups <<< "$lookup_arg"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  for lookup in "${lookups[@]}"; do
+    if grep -q -E "^\[[0-9].*\]" <<<"$lookup"; then
+      # looks like an IPv6 address, eg [2001:DB8::1] or [2001:DB8::1]:2181
+      # getent does not support the bracket notation, but does support IPv6 addresses
+      host=$(sed -E 's/\[(.*)\].*/\1/' <<<"$lookup")
+      port=$(sed -E 's/^\[(.*)\]:?//' <<<"$lookup")
+    else
+      # IPv4, just split on :
+      IFS=: read -ra split <<<"$lookup"
+      host="${split[0]}"
+      port="${split[1]:-}"
+    fi
+    if [[ "${VERBOSE:-}" == "yes" ]]; then
+      echo "Parsed host=$host port=${port:-}"
+    fi
+    if getent hosts "$host" > $TMP_HOSTS; then
+      while read -r ip hostname ; do
+        echo "${hostname:-}">/dev/null # consume for shellcheck
+        check_zookeeper "$ip" "$port"
+      done <$TMP_HOSTS
+    else
+      echo "Cannot find $lookup yet"
+    fi
+  done
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done
+
+# To test the parsing:
+#  bash scripts/wait-for-zookeeper.sh foo
+#  bash scripts/wait-for-zookeeper.sh 'ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2'
+#  ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2 bash scripts/wait-for-zookeeper.sh

--- a/8.1/slim/Dockerfile
+++ b/8.1/slim/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/8.1/slim/scripts/wait-for-zookeeper.sh
+++ b/8.1/slim/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+#
+# If no argument is provided, but a Solr-style ZK_HOST is set,
+# that will be used. If neither is provided, the default
+# name is 'solr-zookeeper-headless', to match the helm chart.
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    local port="${2:-2181}"
+    if ! echo srvr | nc "$host" "$port" > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup_arg:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup_arg=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup_arg:-}" ]; then
+  if [ -n "$ZK_HOST" ]; then
+    lookup_arg="$ZK_HOST"
+  else
+    lookup_arg=solr-zookeeper-headless
+  fi
+fi
+
+echo "Looking up '$lookup_arg'"
+# split on commas, for when a ZK_HOST string like zoo1:2181,zoo2:2181 is used
+IFS=',' read -ra lookups <<< "$lookup_arg"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  for lookup in "${lookups[@]}"; do
+    if grep -q -E "^\[[0-9].*\]" <<<"$lookup"; then
+      # looks like an IPv6 address, eg [2001:DB8::1] or [2001:DB8::1]:2181
+      # getent does not support the bracket notation, but does support IPv6 addresses
+      host=$(sed -E 's/\[(.*)\].*/\1/' <<<"$lookup")
+      port=$(sed -E 's/^\[(.*)\]:?//' <<<"$lookup")
+    else
+      # IPv4, just split on :
+      IFS=: read -ra split <<<"$lookup"
+      host="${split[0]}"
+      port="${split[1]:-}"
+    fi
+    if [[ "${VERBOSE:-}" == "yes" ]]; then
+      echo "Parsed host=$host port=${port:-}"
+    fi
+    if getent hosts "$host" > $TMP_HOSTS; then
+      while read -r ip hostname ; do
+        echo "${hostname:-}">/dev/null # consume for shellcheck
+        check_zookeeper "$ip" "$port"
+      done <$TMP_HOSTS
+    else
+      echo "Cannot find $lookup yet"
+    fi
+  done
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done
+
+# To test the parsing:
+#  bash scripts/wait-for-zookeeper.sh foo
+#  bash scripts/wait-for-zookeeper.sh 'ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2'
+#  ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2 bash scripts/wait-for-zookeeper.sh

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/8.2/scripts/wait-for-zookeeper.sh
+++ b/8.2/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+#
+# If no argument is provided, but a Solr-style ZK_HOST is set,
+# that will be used. If neither is provided, the default
+# name is 'solr-zookeeper-headless', to match the helm chart.
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    local port="${2:-2181}"
+    if ! echo srvr | nc "$host" "$port" > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup_arg:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup_arg=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup_arg:-}" ]; then
+  if [ -n "$ZK_HOST" ]; then
+    lookup_arg="$ZK_HOST"
+  else
+    lookup_arg=solr-zookeeper-headless
+  fi
+fi
+
+echo "Looking up '$lookup_arg'"
+# split on commas, for when a ZK_HOST string like zoo1:2181,zoo2:2181 is used
+IFS=',' read -ra lookups <<< "$lookup_arg"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  for lookup in "${lookups[@]}"; do
+    if grep -q -E "^\[[0-9].*\]" <<<"$lookup"; then
+      # looks like an IPv6 address, eg [2001:DB8::1] or [2001:DB8::1]:2181
+      # getent does not support the bracket notation, but does support IPv6 addresses
+      host=$(sed -E 's/\[(.*)\].*/\1/' <<<"$lookup")
+      port=$(sed -E 's/^\[(.*)\]:?//' <<<"$lookup")
+    else
+      # IPv4, just split on :
+      IFS=: read -ra split <<<"$lookup"
+      host="${split[0]}"
+      port="${split[1]:-}"
+    fi
+    if [[ "${VERBOSE:-}" == "yes" ]]; then
+      echo "Parsed host=$host port=${port:-}"
+    fi
+    if getent hosts "$host" > $TMP_HOSTS; then
+      while read -r ip hostname ; do
+        echo "${hostname:-}">/dev/null # consume for shellcheck
+        check_zookeeper "$ip" "$port"
+      done <$TMP_HOSTS
+    else
+      echo "Cannot find $lookup yet"
+    fi
+  done
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done
+
+# To test the parsing:
+#  bash scripts/wait-for-zookeeper.sh foo
+#  bash scripts/wait-for-zookeeper.sh 'ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2'
+#  ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2 bash scripts/wait-for-zookeeper.sh

--- a/8.2/slim/Dockerfile
+++ b/8.2/slim/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/8.2/slim/scripts/wait-for-zookeeper.sh
+++ b/8.2/slim/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+#
+# If no argument is provided, but a Solr-style ZK_HOST is set,
+# that will be used. If neither is provided, the default
+# name is 'solr-zookeeper-headless', to match the helm chart.
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    local port="${2:-2181}"
+    if ! echo srvr | nc "$host" "$port" > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup_arg:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup_arg=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup_arg:-}" ]; then
+  if [ -n "$ZK_HOST" ]; then
+    lookup_arg="$ZK_HOST"
+  else
+    lookup_arg=solr-zookeeper-headless
+  fi
+fi
+
+echo "Looking up '$lookup_arg'"
+# split on commas, for when a ZK_HOST string like zoo1:2181,zoo2:2181 is used
+IFS=',' read -ra lookups <<< "$lookup_arg"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  for lookup in "${lookups[@]}"; do
+    if grep -q -E "^\[[0-9].*\]" <<<"$lookup"; then
+      # looks like an IPv6 address, eg [2001:DB8::1] or [2001:DB8::1]:2181
+      # getent does not support the bracket notation, but does support IPv6 addresses
+      host=$(sed -E 's/\[(.*)\].*/\1/' <<<"$lookup")
+      port=$(sed -E 's/^\[(.*)\]:?//' <<<"$lookup")
+    else
+      # IPv4, just split on :
+      IFS=: read -ra split <<<"$lookup"
+      host="${split[0]}"
+      port="${split[1]:-}"
+    fi
+    if [[ "${VERBOSE:-}" == "yes" ]]; then
+      echo "Parsed host=$host port=${port:-}"
+    fi
+    if getent hosts "$host" > $TMP_HOSTS; then
+      while read -r ip hostname ; do
+        echo "${hostname:-}">/dev/null # consume for shellcheck
+        check_zookeeper "$ip" "$port"
+      done <$TMP_HOSTS
+    else
+      echo "Cannot find $lookup yet"
+    fi
+  done
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done
+
+# To test the parsing:
+#  bash scripts/wait-for-zookeeper.sh foo
+#  bash scripts/wait-for-zookeeper.sh 'ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2'
+#  ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2 bash scripts/wait-for-zookeeper.sh

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -1,0 +1,118 @@
+
+FROM openjdk:11-stretch
+
+LABEL maintainer="Martijn Koster \"mak-docker@greenhills.co.uk\""
+LABEL repository="https://github.com/docker-solr/docker-solr"
+
+# Override the solr download location with e.g.:
+#   docker build -t mine --build-arg SOLR_DOWNLOAD_SERVER=http://www-eu.apache.org/dist/lucene/solr .
+ARG SOLR_DOWNLOAD_SERVER
+
+RUN set -e; \
+  apt-get update; \
+  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  rm -rf /var/lib/apt/lists/*
+
+ENV SOLR_USER="solr" \
+    SOLR_UID="8983" \
+    SOLR_GROUP="solr" \
+    SOLR_GID="8983" \
+    SOLR_VERSION="8.3.0" \
+    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/8.3.0/solr-8.3.0.tgz" \
+    SOLR_SHA256="1a9820915186227eaf6fcb851d60690853911b92a15b4e0b7f046324eb8d1387" \
+    SOLR_KEYS="2085660D9C1FCCACC4A479A3BF160FF14992A24C" \
+    PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH" \
+    SOLR_INCLUDE=/etc/default/solr.in.sh \
+    SOLR_HOME=/var/solr/data \
+    SOLR_PID_DIR=/var/solr \
+    SOLR_LOGS_DIR=/var/solr/logs \
+    LOG4J_PROPS=/var/solr/log4j2.xml
+
+ENV GOSU_VERSION 1.11
+ENV GOSU_KEY B42F6819007F00F88E364FD4036A9C25BF357DD4
+
+ENV TINI_VERSION v0.18.0
+ENV TINI_KEY 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7
+
+RUN set -x; \
+  groupadd -r --gid "$SOLR_GID" "$SOLR_GROUP"; \
+  useradd -r --uid "$SOLR_UID" --gid "$SOLR_GID" "$SOLR_USER"
+
+RUN set -e; \
+  export GNUPGHOME="/tmp/gnupg_home"; \
+  mkdir -p "$GNUPGHOME"; \
+  chmod 700 "$GNUPGHOME"; \
+  echo "disable-ipv6" >> "$GNUPGHOME/dirmngr.conf"; \
+  for key in $SOLR_KEYS $GOSU_KEY $TINI_KEY; do \
+    found=''; \
+    for server in \
+      ha.pool.sks-keyservers.net \
+      hkp://keyserver.ubuntu.com:80 \
+      hkp://p80.pool.sks-keyservers.net:80 \
+      pgp.mit.edu \
+    ; do \
+      echo "  trying $server for $key"; \
+      gpg --batch --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
+      gpg --batch --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch $key from several disparate servers -- network issues?" && exit 1; \
+  done; \
+  exit 0
+
+RUN set -e; \
+  export GNUPGHOME="/tmp/gnupg_home"; \
+  pkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+  wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$pkgArch"; \
+  wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$pkgArch.asc"; \
+  gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+  rm /usr/local/bin/gosu.asc; \
+  chmod +x /usr/local/bin/gosu; \
+  gosu nobody true; \
+  wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-$pkgArch"; \
+  wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-$pkgArch.asc"; \
+  gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini; \
+  rm /usr/local/bin/tini.asc; \
+  chmod +x /usr/local/bin/tini; \
+  tini --version; \
+  echo "downloading $SOLR_URL"; \
+  wget -nv "$SOLR_URL" -O "/opt/solr-$SOLR_VERSION.tgz"; \
+  echo "downloading $SOLR_URL.asc"; \
+  wget -nv "$SOLR_URL.asc" -O "/opt/solr-$SOLR_VERSION.tgz.asc"; \
+  echo "$SOLR_SHA256 */opt/solr-$SOLR_VERSION.tgz" | sha256sum -c -; \
+  (>&2 ls -l "/opt/solr-$SOLR_VERSION.tgz" "/opt/solr-$SOLR_VERSION.tgz.asc"); \
+  gpg --batch --verify "/opt/solr-$SOLR_VERSION.tgz.asc" "/opt/solr-$SOLR_VERSION.tgz"; \
+  tar -C /opt --extract --file "/opt/solr-$SOLR_VERSION.tgz"; \
+  (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
+  rm "/opt/solr-$SOLR_VERSION.tgz"*; \
+  rm -Rf /opt/solr/docs/; \
+  mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
+  chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
+  find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \
+  find "/opt/solr-$SOLR_VERSION" -type f -print0 | xargs -0 chmod 0644; \
+  chmod -R 0755 "/opt/solr-$SOLR_VERSION/bin" "/opt/solr-$SOLR_VERSION/contrib/prometheus-exporter/bin/solr-exporter" /opt/solr-$SOLR_VERSION/server/scripts/cloud-scripts; \
+  cp /opt/solr/bin/solr.in.sh /etc/default/solr.in.sh; \
+  mv /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig; \
+  mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
+  chown root:0 /etc/default/solr.in.sh; \
+  chmod 0664 /etc/default/solr.in.sh; \
+  mkdir -p /var/solr/data /var/solr/logs; \
+  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
+  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
+  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
+  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
+  chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \
+  chown -R "$SOLR_USER:0" /var/solr; \
+  { command -v gpgconf; gpgconf --kill all || :; }; \
+  rm -r "$GNUPGHOME"
+
+COPY --chown=0:0 scripts /opt/docker-solr/scripts
+
+VOLUME /var/solr
+EXPOSE 8983
+WORKDIR /opt/solr
+USER $SOLR_USER
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["solr-foreground"]

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11-stretch
+FROM openjdk:13-buster
 
 LABEL maintainer="Martijn Koster \"mak-docker@greenhills.co.uk\""
 LABEL repository="https://github.com/docker-solr/docker-solr"

--- a/8.3/scripts/docker-entrypoint.sh
+++ b/8.3/scripts/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" == "yes" ]]; then
+    set -x
+fi
+
+if [[ -v SOLR_PORT ]] && ! grep -E -q '^[0-9]+$' <<<"${SOLR_PORT:-}"; then
+  SOLR_PORT=8983
+  export SOLR_PORT
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" == '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/8.3/scripts/init-var-solr
+++ b/8.3/scripts/init-var-solr
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# A helper script to initialise an empty $DIR
+# If you use volumes then Docker will copy the $DIR content from the container to the volume.
+# If you use bind mounts, that does not happen, so we do it here.
+
+set -e
+
+if [[ "$VERBOSE" == "yes" ]]; then
+    set -x
+fi
+
+if [[ -n "${NO_INIT_VAR_SOLR:-}" ]]; then
+    exit 0
+fi
+
+DIR=${1:-/var/solr}
+
+if [ ! -d "$DIR" ]; then
+    echo "Missing $DIR"
+    exit 1
+fi
+
+function check_dir_writability {
+    local dir="$1"
+    if [ ! -w "$dir" ]; then
+        echo "Cannot write to $dir as $(id -u):$(id -g)"
+        ls -ld "$dir"
+        exit 1
+    fi
+}
+
+if [ ! -d "$DIR/data" ]; then
+    echo "Creating $DIR/data"
+    check_dir_writability "$DIR"
+    mkdir "$DIR/data"
+    chmod 0770 "$DIR/data"
+fi
+
+if [ ! -d "$DIR/logs" ]; then
+    echo "Creating $DIR/logs"
+    check_dir_writability "$DIR"
+    mkdir "$DIR/logs"
+    chmod 0770 "$DIR/logs"
+fi
+
+if [ ! -f "$DIR/data/solr.xml" ]; then
+    echo "Copying solr.xml"
+    cp -a /opt/solr/server/solr/solr.xml "$DIR/data/solr.xml"
+fi
+
+if [ ! -f "$DIR/data/zoo.cfg" ]; then
+    echo "Copying zoo.cfg"
+    cp -a /opt/solr/server/solr/zoo.cfg "$DIR/data/zoo.cfg"
+fi
+
+if [ ! -f "$DIR/log4j2.xml" ]; then
+    echo "Copying log4j2.xml"
+    cp -a /opt/solr/server/resources/log4j2.xml "$DIR/log4j2.xml"
+fi
+

--- a/8.3/scripts/oom_solr.sh
+++ b/8.3/scripts/oom_solr.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Custom oom handler loosely based on
+# https://github.com/apache/lucene-solr/blob/master/solr/bin/oom_solr.sh
+# See solr-forgeground for how to configure OOM behaviour
+
+if [[ -z "${SOLR_LOGS_DIR:-}" ]]; then
+    if -d /var/solr/logs; then
+        SOLR_LOGS_DIR=/var/solr/logs
+    elif -d /opt/solr/server/logs; then
+        SOLR_LOGS_DIR=/opt/solr/server/logs
+    else
+        echo "Cannot determine SOLR_LOGS_DIR!"
+        exit 1
+    fi
+fi
+SOLR_PID=$(pgrep -f start.jar)
+if [[ -z "$SOLR_PID" ]]; then
+  echo "Couldn't find Solr process running!"
+  exit
+fi
+
+NOW=$(date +"%F_%H_%M_%S")
+(
+echo "Running OOM killer script for Solr process $SOLR_PID"
+if [[ "$SOLR_PID" == 1 ]]; then
+  # under Docker, when running as pid 1, a SIGKILL is ignored,
+  # so use the default SIGTERM
+  kill "$SOLR_PID"
+  sleep 2
+  # if that hasn't worked, send SIGKILL
+  kill -SIGILL "$SOLR_PID"
+else
+  # if we're running with `--init` or under tini or similar,
+  # follow the upstream behaviour
+  kill -9 "$SOLR_PID"
+fi
+) | tee "$SOLR_LOGS_DIR/solr_oom_killer-$SOLR_PORT-$NOW.log"

--- a/8.3/scripts/precreate-core
+++ b/8.3/scripts/precreate-core
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Create a core on disk
+# arguments are: corename configdir
+
+set -e
+
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE="${2:-}"
+if [[ -z "$CONFIG_SOURCE" ]]; then
+    DEFAULT_CONFIGS=(_default data_driven_schema_configs)
+    for config_dir in "${DEFAULT_CONFIGS[@]}"; do
+        config_dir="/opt/solr/server/solr/configsets/$config_dir"
+        if [ -d "$config_dir" ]; then
+           CONFIG_SOURCE="$config_dir"
+           break
+        fi
+    done
+    if [[ -z $CONFIG_SOURCE ]]; then
+        echo "Cannot find default config"
+        exit 1
+    fi
+fi
+
+coresdir=/var/solr/data
+
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r "$CONFIG_SOURCE/" "$coredir"
+    touch "$coredir/core.properties"
+    echo "Created $CORE"
+else
+    echo "Core $CORE already exists"
+fi

--- a/8.3/scripts/run-initdb
+++ b/8.3/scripts/run-initdb
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read -r f; do
+    case "$f" in
+        *.sh)     echo "$0: running $f"; . "$f" ;;
+        *)        echo "$0: ignoring $f" ;;
+    esac
+    echo
+done < <(find /docker-entrypoint-initdb.d/ -mindepth 1 -type f | sort -n)

--- a/8.3/scripts/solr-create
+++ b/8.3/scripts/solr-create
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+
+set -euo pipefail
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
+. /opt/docker-solr/scripts/run-initdb
+
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "Could not determine core name"
+  exit 1
+fi
+
+coresdir=/var/solr/data
+CORE_DIR="$coresdir/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "Directory $CORE_DIR exists; skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with:" "${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - "http://localhost:${SOLR_PORT:-8983}/solr/admin/cores?action=STATUS" | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with:" "${@:1}"
+    stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+
+exec solr-fg

--- a/8.3/scripts/solr-demo
+++ b/8.3/scripts/solr-demo
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=demo
+
+coresdir=/var/solr/data
+CORE_DIR="$coresdir/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
+else
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  post_args=()
+  if [[ -n "${SOLR_PORT:-}" ]]; then
+    post_args+=(-p "$SOLR_PORT")
+  fi
+  /opt/solr/bin/post "${post_args[@]}" -c $CORE -commit no example/exampledocs/*.xml
+  /opt/solr/bin/post "${post_args[@]}" -c $CORE -commit no example/exampledocs/books.json
+  /opt/solr/bin/post "${post_args[@]}" -c $CORE -commit yes example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+
+exec solr-fg

--- a/8.3/scripts/solr-fg
+++ b/8.3/scripts/solr-fg
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" == "yes" ]]; then
+    set -x
+fi
+
+EXTRA_ARGS=()
+
+# Allow easy setting of the OOM behaviour
+# Test with: docker run -p 8983:8983 -it -e OOM=script -e SOLR_JAVA_MEM="-Xms25m -Xmx25m" solr
+if [[ -z "${OOM:-}" ]]; then
+  OOM='none'
+fi
+case "$OOM" in
+  'script')
+    EXTRA_ARGS+=(-a '-XX:OnOutOfMemoryError=/opt/docker-solr/scripts/oom_solr.sh')
+    ;;
+  'exit')
+    # recommended
+    EXTRA_ARGS+=(-a '-XX:+ExitOnOutOfMemoryError')
+    ;;
+  'crash')
+    EXTRA_ARGS+=(-a '-XX:+CrashOnOutOfMemoryError')
+    ;;
+  'none'|'')
+    ;;
+  *)
+   echo "Unsupported value in OOM=$OOM"
+   exit 1
+esac
+
+echo "Starting Solr $SOLR_VERSION"
+# determine TINI default. If it is already set, assume the user knows what they want
+if [[ -z "${TINI:-}" ]]; then
+  if [[ "$$" == 1 ]]; then
+    # Default to running tini, so we can run with an OOM script and have 'kill -9' work
+    TINI=yes
+  else
+    # Presumably we're already running under tini through 'docker --init', in which case we
+    # don't need to run it twice.
+    # It's also possible that we're run from a wrapper script without exec,
+    # in which case running tini would not be ideal either.
+    TINI=no
+  fi
+fi
+if [[ "$TINI" == yes ]]; then
+  exec /usr/local/bin/tini -- solr -f "$@" "${EXTRA_ARGS[@]}"
+elif [[ "$TINI" == no ]]; then
+  exec solr -f "$@" "${EXTRA_ARGS[@]}"
+else
+  echo "invalid value TINI=$TINI"
+  exit 1
+fi

--- a/8.3/scripts/solr-foreground
+++ b/8.3/scripts/solr-foreground
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" == "yes" ]]; then
+    set -x
+fi
+
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
+. /opt/docker-solr/scripts/run-initdb
+
+exec solr-fg "$@"

--- a/8.3/scripts/solr-precreate
+++ b/8.3/scripts/solr-precreate
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir myvarsolr; chown 8983:8983 myvarsolr
+#      docker run -it --rm -P -v $PWD/myvarsolr://var/solr solr solr-precreate mycore
+set -e
+
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
+. /opt/docker-solr/scripts/run-initdb
+
+/opt/docker-solr/scripts/precreate-core "$@"
+
+exec solr-fg

--- a/8.3/scripts/start-local-solr
+++ b/8.3/scripts/start-local-solr
@@ -1,0 +1,21 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+echo "Running solr in the background. Logs are in /var/solr/logs"
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f "/var/solr/logs/solr.log" ]; then
+        echo "Here is the log:"
+        cat "/var/solr/logs/solr.log"
+    fi
+    exit 1
+fi

--- a/8.3/scripts/stop-local-solr
+++ b/8.3/scripts/stop-local-solr
@@ -1,0 +1,11 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" == "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop

--- a/8.3/scripts/wait-for-solr.sh
+++ b/8.3/scripts/wait-for-solr.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [--max-attempts count] [--wait-seconds seconds] [--solr-url url]
+# Deprecated usage: wait-for-solr.sh [ max_attempts [ wait_seconds ] ]
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] [--solr-url url]"
+  exit 1
+}
+
+max_attempts=12
+wait_seconds=5
+
+if [[ -v SOLR_PORT ]] && ! grep -E -q '^[0-9]+$' <<<"$SOLR_PORT"; then
+  echo "Invalid SOLR_PORT=$SOLR_PORT environment variable specified"
+  exit 1
+fi
+
+solr_url="http://localhost:${SOLR_PORT:-8983}"
+
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options]
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+  --solr-url url: URL for Solr server to check. Default: $solr_url
+EOM
+     exit 0
+     ;;
+   --solr-url)
+     solr_url="$2";
+     shift 2
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+  * )
+    # deprecated invocation, kept for backwards compatibility
+    max_attempts=$1;
+    wait_seconds=$2;
+    echo "WARNING: deprecated invocation. Use $SCRIPT [--max-attempts count] [--wait-seconds seconds]"
+    shift 2;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL"
+
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if wget -q -O - "$solr_url" | grep -q -i solr; then
+    break
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Solr is still not running; giving up"
+    exit 1
+  fi
+  if (( attempts_left == 1 )); then
+    attempts=attempt
+  else
+    attempts=attempts
+  fi
+  echo "Solr is not running yet on $solr_url. $attempts_left $attempts left"
+  sleep "$wait_seconds"
+done
+echo "Solr is running on $solr_url"

--- a/8.3/scripts/wait-for-zookeeper.sh
+++ b/8.3/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+#
+# If no argument is provided, but a Solr-style ZK_HOST is set,
+# that will be used. If neither is provided, the default
+# name is 'solr-zookeeper-headless', to match the helm chart.
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    local port="${2:-2181}"
+    if ! echo srvr | nc "$host" "$port" > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup_arg:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup_arg=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup_arg:-}" ]; then
+  if [ -n "$ZK_HOST" ]; then
+    lookup_arg="$ZK_HOST"
+  else
+    lookup_arg=solr-zookeeper-headless
+  fi
+fi
+
+echo "Looking up '$lookup_arg'"
+# split on commas, for when a ZK_HOST string like zoo1:2181,zoo2:2181 is used
+IFS=',' read -ra lookups <<< "$lookup_arg"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  for lookup in "${lookups[@]}"; do
+    if grep -q -E "^\[[0-9].*\]" <<<"$lookup"; then
+      # looks like an IPv6 address, eg [2001:DB8::1] or [2001:DB8::1]:2181
+      # getent does not support the bracket notation, but does support IPv6 addresses
+      host=$(sed -E 's/\[(.*)\].*/\1/' <<<"$lookup")
+      port=$(sed -E 's/^\[(.*)\]:?//' <<<"$lookup")
+    else
+      # IPv4, just split on :
+      IFS=: read -ra split <<<"$lookup"
+      host="${split[0]}"
+      port="${split[1]:-}"
+    fi
+    if [[ "${VERBOSE:-}" == "yes" ]]; then
+      echo "Parsed host=$host port=${port:-}"
+    fi
+    if getent hosts "$host" > $TMP_HOSTS; then
+      while read -r ip hostname ; do
+        echo "${hostname:-}">/dev/null # consume for shellcheck
+        check_zookeeper "$ip" "$port"
+      done <$TMP_HOSTS
+    else
+      echo "Cannot find $lookup yet"
+    fi
+  done
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done
+
+# To test the parsing:
+#  bash scripts/wait-for-zookeeper.sh foo
+#  bash scripts/wait-for-zookeeper.sh 'ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2'
+#  ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2 bash scripts/wait-for-zookeeper.sh

--- a/8.3/slim/Dockerfile
+++ b/8.3/slim/Dockerfile
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/8.3/slim/Dockerfile
+++ b/8.3/slim/Dockerfile
@@ -1,0 +1,118 @@
+
+FROM openjdk:11-slim
+
+LABEL maintainer="Martijn Koster \"mak-docker@greenhills.co.uk\""
+LABEL repository="https://github.com/docker-solr/docker-solr"
+
+# Override the solr download location with e.g.:
+#   docker build -t mine --build-arg SOLR_DOWNLOAD_SERVER=http://www-eu.apache.org/dist/lucene/solr .
+ARG SOLR_DOWNLOAD_SERVER
+
+RUN set -e; \
+  apt-get update; \
+  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  rm -rf /var/lib/apt/lists/*
+
+ENV SOLR_USER="solr" \
+    SOLR_UID="8983" \
+    SOLR_GROUP="solr" \
+    SOLR_GID="8983" \
+    SOLR_VERSION="8.3.0" \
+    SOLR_URL="${SOLR_DOWNLOAD_SERVER:-https://archive.apache.org/dist/lucene/solr}/8.3.0/solr-8.3.0.tgz" \
+    SOLR_SHA256="1a9820915186227eaf6fcb851d60690853911b92a15b4e0b7f046324eb8d1387" \
+    SOLR_KEYS="2085660D9C1FCCACC4A479A3BF160FF14992A24C" \
+    PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH" \
+    SOLR_INCLUDE=/etc/default/solr.in.sh \
+    SOLR_HOME=/var/solr/data \
+    SOLR_PID_DIR=/var/solr \
+    SOLR_LOGS_DIR=/var/solr/logs \
+    LOG4J_PROPS=/var/solr/log4j2.xml
+
+ENV GOSU_VERSION 1.11
+ENV GOSU_KEY B42F6819007F00F88E364FD4036A9C25BF357DD4
+
+ENV TINI_VERSION v0.18.0
+ENV TINI_KEY 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7
+
+RUN set -x; \
+  groupadd -r --gid "$SOLR_GID" "$SOLR_GROUP"; \
+  useradd -r --uid "$SOLR_UID" --gid "$SOLR_GID" "$SOLR_USER"
+
+RUN set -e; \
+  export GNUPGHOME="/tmp/gnupg_home"; \
+  mkdir -p "$GNUPGHOME"; \
+  chmod 700 "$GNUPGHOME"; \
+  echo "disable-ipv6" >> "$GNUPGHOME/dirmngr.conf"; \
+  for key in $SOLR_KEYS $GOSU_KEY $TINI_KEY; do \
+    found=''; \
+    for server in \
+      ha.pool.sks-keyservers.net \
+      hkp://keyserver.ubuntu.com:80 \
+      hkp://p80.pool.sks-keyservers.net:80 \
+      pgp.mit.edu \
+    ; do \
+      echo "  trying $server for $key"; \
+      gpg --batch --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
+      gpg --batch --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch $key from several disparate servers -- network issues?" && exit 1; \
+  done; \
+  exit 0
+
+RUN set -e; \
+  export GNUPGHOME="/tmp/gnupg_home"; \
+  pkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+  wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$pkgArch"; \
+  wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$pkgArch.asc"; \
+  gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+  rm /usr/local/bin/gosu.asc; \
+  chmod +x /usr/local/bin/gosu; \
+  gosu nobody true; \
+  wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-$pkgArch"; \
+  wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-$pkgArch.asc"; \
+  gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini; \
+  rm /usr/local/bin/tini.asc; \
+  chmod +x /usr/local/bin/tini; \
+  tini --version; \
+  echo "downloading $SOLR_URL"; \
+  wget -nv "$SOLR_URL" -O "/opt/solr-$SOLR_VERSION.tgz"; \
+  echo "downloading $SOLR_URL.asc"; \
+  wget -nv "$SOLR_URL.asc" -O "/opt/solr-$SOLR_VERSION.tgz.asc"; \
+  echo "$SOLR_SHA256 */opt/solr-$SOLR_VERSION.tgz" | sha256sum -c -; \
+  (>&2 ls -l "/opt/solr-$SOLR_VERSION.tgz" "/opt/solr-$SOLR_VERSION.tgz.asc"); \
+  gpg --batch --verify "/opt/solr-$SOLR_VERSION.tgz.asc" "/opt/solr-$SOLR_VERSION.tgz"; \
+  tar -C /opt --extract --file "/opt/solr-$SOLR_VERSION.tgz"; \
+  (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
+  rm "/opt/solr-$SOLR_VERSION.tgz"*; \
+  rm -Rf /opt/solr/docs/; \
+  mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
+  chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
+  find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \
+  find "/opt/solr-$SOLR_VERSION" -type f -print0 | xargs -0 chmod 0644; \
+  chmod -R 0755 "/opt/solr-$SOLR_VERSION/bin" "/opt/solr-$SOLR_VERSION/contrib/prometheus-exporter/bin/solr-exporter" /opt/solr-$SOLR_VERSION/server/scripts/cloud-scripts; \
+  cp /opt/solr/bin/solr.in.sh /etc/default/solr.in.sh; \
+  mv /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig; \
+  mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
+  chown root:0 /etc/default/solr.in.sh; \
+  chmod 0664 /etc/default/solr.in.sh; \
+  mkdir -p /var/solr/data /var/solr/logs; \
+  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
+  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
+  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
+  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
+  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
+  chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \
+  chown -R "$SOLR_USER:0" /var/solr; \
+  { command -v gpgconf; gpgconf --kill all || :; }; \
+  rm -r "$GNUPGHOME"
+
+COPY --chown=0:0 scripts /opt/docker-solr/scripts
+
+VOLUME /var/solr
+EXPOSE 8983
+WORKDIR /opt/solr
+USER $SOLR_USER
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["solr-foreground"]

--- a/8.3/slim/Dockerfile
+++ b/8.3/slim/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11-slim
+FROM openjdk:13-slim
 
 LABEL maintainer="Martijn Koster \"mak-docker@greenhills.co.uk\""
 LABEL repository="https://github.com/docker-solr/docker-solr"

--- a/8.3/slim/scripts/docker-entrypoint.sh
+++ b/8.3/slim/scripts/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# docker-entrypoint for docker-solr
+
+set -e
+
+if [[ "$VERBOSE" == "yes" ]]; then
+    set -x
+fi
+
+if [[ -v SOLR_PORT ]] && ! grep -E -q '^[0-9]+$' <<<"${SOLR_PORT:-}"; then
+  SOLR_PORT=8983
+  export SOLR_PORT
+fi
+
+# when invoked with e.g.: docker run solr -help
+if [ "${1:0:1}" == '-' ]; then
+    set -- solr-foreground "$@"
+fi
+
+# execute command passed in as arguments.
+# The Dockerfile has specified the PATH to include
+# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# like solr-foreground, solr-create, solr-precreate, solr-demo).
+# Note: if you specify "solr", you'll typically want to add -f to run it in
+# the foreground.
+exec "$@"

--- a/8.3/slim/scripts/init-var-solr
+++ b/8.3/slim/scripts/init-var-solr
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# A helper script to initialise an empty $DIR
+# If you use volumes then Docker will copy the $DIR content from the container to the volume.
+# If you use bind mounts, that does not happen, so we do it here.
+
+set -e
+
+if [[ "$VERBOSE" == "yes" ]]; then
+    set -x
+fi
+
+if [[ -n "${NO_INIT_VAR_SOLR:-}" ]]; then
+    exit 0
+fi
+
+DIR=${1:-/var/solr}
+
+if [ ! -d "$DIR" ]; then
+    echo "Missing $DIR"
+    exit 1
+fi
+
+function check_dir_writability {
+    local dir="$1"
+    if [ ! -w "$dir" ]; then
+        echo "Cannot write to $dir as $(id -u):$(id -g)"
+        ls -ld "$dir"
+        exit 1
+    fi
+}
+
+if [ ! -d "$DIR/data" ]; then
+    echo "Creating $DIR/data"
+    check_dir_writability "$DIR"
+    mkdir "$DIR/data"
+    chmod 0770 "$DIR/data"
+fi
+
+if [ ! -d "$DIR/logs" ]; then
+    echo "Creating $DIR/logs"
+    check_dir_writability "$DIR"
+    mkdir "$DIR/logs"
+    chmod 0770 "$DIR/logs"
+fi
+
+if [ ! -f "$DIR/data/solr.xml" ]; then
+    echo "Copying solr.xml"
+    cp -a /opt/solr/server/solr/solr.xml "$DIR/data/solr.xml"
+fi
+
+if [ ! -f "$DIR/data/zoo.cfg" ]; then
+    echo "Copying zoo.cfg"
+    cp -a /opt/solr/server/solr/zoo.cfg "$DIR/data/zoo.cfg"
+fi
+
+if [ ! -f "$DIR/log4j2.xml" ]; then
+    echo "Copying log4j2.xml"
+    cp -a /opt/solr/server/resources/log4j2.xml "$DIR/log4j2.xml"
+fi
+

--- a/8.3/slim/scripts/oom_solr.sh
+++ b/8.3/slim/scripts/oom_solr.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Custom oom handler loosely based on
+# https://github.com/apache/lucene-solr/blob/master/solr/bin/oom_solr.sh
+# See solr-forgeground for how to configure OOM behaviour
+
+if [[ -z "${SOLR_LOGS_DIR:-}" ]]; then
+    if -d /var/solr/logs; then
+        SOLR_LOGS_DIR=/var/solr/logs
+    elif -d /opt/solr/server/logs; then
+        SOLR_LOGS_DIR=/opt/solr/server/logs
+    else
+        echo "Cannot determine SOLR_LOGS_DIR!"
+        exit 1
+    fi
+fi
+SOLR_PID=$(pgrep -f start.jar)
+if [[ -z "$SOLR_PID" ]]; then
+  echo "Couldn't find Solr process running!"
+  exit
+fi
+
+NOW=$(date +"%F_%H_%M_%S")
+(
+echo "Running OOM killer script for Solr process $SOLR_PID"
+if [[ "$SOLR_PID" == 1 ]]; then
+  # under Docker, when running as pid 1, a SIGKILL is ignored,
+  # so use the default SIGTERM
+  kill "$SOLR_PID"
+  sleep 2
+  # if that hasn't worked, send SIGKILL
+  kill -SIGILL "$SOLR_PID"
+else
+  # if we're running with `--init` or under tini or similar,
+  # follow the upstream behaviour
+  kill -9 "$SOLR_PID"
+fi
+) | tee "$SOLR_LOGS_DIR/solr_oom_killer-$SOLR_PORT-$NOW.log"

--- a/8.3/slim/scripts/precreate-core
+++ b/8.3/slim/scripts/precreate-core
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Create a core on disk
+# arguments are: corename configdir
+
+set -e
+
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+CORE=${1:-gettingstarted}
+CONFIG_SOURCE="${2:-}"
+if [[ -z "$CONFIG_SOURCE" ]]; then
+    DEFAULT_CONFIGS=(_default data_driven_schema_configs)
+    for config_dir in "${DEFAULT_CONFIGS[@]}"; do
+        config_dir="/opt/solr/server/solr/configsets/$config_dir"
+        if [ -d "$config_dir" ]; then
+           CONFIG_SOURCE="$config_dir"
+           break
+        fi
+    done
+    if [[ -z $CONFIG_SOURCE ]]; then
+        echo "Cannot find default config"
+        exit 1
+    fi
+fi
+
+coresdir=/var/solr/data
+
+coredir="$coresdir/$CORE"
+if [[ ! -d $coredir ]]; then
+    cp -r "$CONFIG_SOURCE/" "$coredir"
+    touch "$coredir/core.properties"
+    echo "Created $CORE"
+else
+    echo "Core $CORE already exists"
+fi

--- a/8.3/slim/scripts/run-initdb
+++ b/8.3/slim/scripts/run-initdb
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Run the init-solr-home script and source any '.sh' scripts in
+# /docker-entrypoint-initdb.d.
+# This script is sourced by some of the solr-* commands, so that
+# you can run eg:
+#
+#   mkdir initdb; echo "echo hi" > initdb/hi.sh
+#   docker run -v $PWD/initdb:/docker-entrypoint-initdb.d solr
+#
+# and have your script execute before Solr starts.
+#
+# Note: scripts can modify the environment, which will affect
+# subsequent scripts and ultimately Solr. That allows you to set
+# environment variables from your scripts (though you usually just
+# use "docker run -e"). If this is undesirable in your use-case,
+# have your scripts execute a sub-shell.
+
+set -e
+
+# execute files in /docker-entrypoint-initdb.d before starting solr
+while read -r f; do
+    case "$f" in
+        *.sh)     echo "$0: running $f"; . "$f" ;;
+        *)        echo "$0: ignoring $f" ;;
+    esac
+    echo
+done < <(find /docker-entrypoint-initdb.d/ -mindepth 1 -type f | sort -n)

--- a/8.3/slim/scripts/solr-create
+++ b/8.3/slim/scripts/solr-create
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+
+set -euo pipefail
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
+. /opt/docker-solr/scripts/run-initdb
+
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "Could not determine core name"
+  exit 1
+fi
+
+coresdir=/var/solr/data
+CORE_DIR="$coresdir/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "Directory $CORE_DIR exists; skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with:" "${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - "http://localhost:${SOLR_PORT:-8983}/solr/admin/cores?action=STATUS" | grep -q instanceDir; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with:" "${@:1}"
+    stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+
+exec solr-fg

--- a/8.3/slim/scripts/solr-demo
+++ b/8.3/slim/scripts/solr-demo
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Configure a Solr demo and then run solr in the foreground
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+. /opt/docker-solr/scripts/run-initdb
+
+CORE=demo
+
+coresdir=/var/solr/data
+CORE_DIR="$coresdir/demo"
+if [ -d "$CORE_DIR" ]; then
+  echo "$CORE_DIR exists; skipping demo creation"
+else
+  start-local-solr
+  echo "Creating $CORE"
+  /opt/solr/bin/solr create -c "$CORE"
+  echo "Created $CORE"
+  echo "Loading example data"
+  post_args=()
+  if [[ -n "${SOLR_PORT:-}" ]]; then
+    post_args+=(-p "$SOLR_PORT")
+  fi
+  /opt/solr/bin/post "${post_args[@]}" -c $CORE -commit no example/exampledocs/*.xml
+  /opt/solr/bin/post "${post_args[@]}" -c $CORE -commit no example/exampledocs/books.json
+  /opt/solr/bin/post "${post_args[@]}" -c $CORE -commit yes example/exampledocs/books.csv
+  echo "Loaded example data"
+  stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+
+exec solr-fg

--- a/8.3/slim/scripts/solr-fg
+++ b/8.3/slim/scripts/solr-fg
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" == "yes" ]]; then
+    set -x
+fi
+
+EXTRA_ARGS=()
+
+# Allow easy setting of the OOM behaviour
+# Test with: docker run -p 8983:8983 -it -e OOM=script -e SOLR_JAVA_MEM="-Xms25m -Xmx25m" solr
+if [[ -z "${OOM:-}" ]]; then
+  OOM='none'
+fi
+case "$OOM" in
+  'script')
+    EXTRA_ARGS+=(-a '-XX:OnOutOfMemoryError=/opt/docker-solr/scripts/oom_solr.sh')
+    ;;
+  'exit')
+    # recommended
+    EXTRA_ARGS+=(-a '-XX:+ExitOnOutOfMemoryError')
+    ;;
+  'crash')
+    EXTRA_ARGS+=(-a '-XX:+CrashOnOutOfMemoryError')
+    ;;
+  'none'|'')
+    ;;
+  *)
+   echo "Unsupported value in OOM=$OOM"
+   exit 1
+esac
+
+echo "Starting Solr $SOLR_VERSION"
+# determine TINI default. If it is already set, assume the user knows what they want
+if [[ -z "${TINI:-}" ]]; then
+  if [[ "$$" == 1 ]]; then
+    # Default to running tini, so we can run with an OOM script and have 'kill -9' work
+    TINI=yes
+  else
+    # Presumably we're already running under tini through 'docker --init', in which case we
+    # don't need to run it twice.
+    # It's also possible that we're run from a wrapper script without exec,
+    # in which case running tini would not be ideal either.
+    TINI=no
+  fi
+fi
+if [[ "$TINI" == yes ]]; then
+  exec /usr/local/bin/tini -- solr -f "$@" "${EXTRA_ARGS[@]}"
+elif [[ "$TINI" == no ]]; then
+  exec solr -f "$@" "${EXTRA_ARGS[@]}"
+else
+  echo "invalid value TINI=$TINI"
+  exit 1
+fi

--- a/8.3/slim/scripts/solr-foreground
+++ b/8.3/slim/scripts/solr-foreground
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Run the initdb, then start solr in the foreground
+set -e
+
+if [[ "$VERBOSE" == "yes" ]]; then
+    set -x
+fi
+
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
+. /opt/docker-solr/scripts/run-initdb
+
+exec solr-fg "$@"

--- a/8.3/slim/scripts/solr-precreate
+++ b/8.3/slim/scripts/solr-precreate
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Create a core on disk and then run solr in the foreground
+# arguments are: corename configdir
+# To simply create a core:
+#      docker run -P -d solr solr-precreate mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-precreate mycore /myconfig
+# To create a core in a mounted directory:
+#      mkdir myvarsolr; chown 8983:8983 myvarsolr
+#      docker run -it --rm -P -v $PWD/myvarsolr://var/solr solr solr-precreate mycore
+set -e
+
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
+. /opt/docker-solr/scripts/run-initdb
+
+/opt/docker-solr/scripts/precreate-core "$@"
+
+exec solr-fg

--- a/8.3/slim/scripts/start-local-solr
+++ b/8.3/slim/scripts/start-local-solr
@@ -1,0 +1,21 @@
+#!/bin/bash
+# configure Solr to run on the local interface, and start it running in the background
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+echo "Running solr in the background. Logs are in /var/solr/logs"
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f "/var/solr/logs/solr.log" ]; then
+        echo "Here is the log:"
+        cat "/var/solr/logs/solr.log"
+    fi
+    exit 1
+fi

--- a/8.3/slim/scripts/stop-local-solr
+++ b/8.3/slim/scripts/stop-local-solr
@@ -1,0 +1,11 @@
+#!/bin/bash
+# stop the background Solr, and restore the normal configuration
+
+set -e
+
+if [[ "$VERBOSE" == "yes" ]]; then
+    set -x
+fi
+
+echo "Shutting down the background Solr"
+solr stop

--- a/8.3/slim/scripts/wait-for-solr.sh
+++ b/8.3/slim/scripts/wait-for-solr.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# A helper script to wait for solr
+#
+# Usage: wait-for-solr.sh [--max-attempts count] [--wait-seconds seconds] [--solr-url url]
+# Deprecated usage: wait-for-solr.sh [ max_attempts [ wait_seconds ] ]
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] [--solr-url url]"
+  exit 1
+}
+
+max_attempts=12
+wait_seconds=5
+
+if [[ -v SOLR_PORT ]] && ! grep -E -q '^[0-9]+$' <<<"$SOLR_PORT"; then
+  echo "Invalid SOLR_PORT=$SOLR_PORT environment variable specified"
+  exit 1
+fi
+
+solr_url="http://localhost:${SOLR_PORT:-8983}"
+
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options]
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+  --solr-url url: URL for Solr server to check. Default: $solr_url
+EOM
+     exit 0
+     ;;
+   --solr-url)
+     solr_url="$2";
+     shift 2
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+  * )
+    # deprecated invocation, kept for backwards compatibility
+    max_attempts=$1;
+    wait_seconds=$2;
+    echo "WARNING: deprecated invocation. Use $SCRIPT [--max-attempts count] [--wait-seconds seconds]"
+    shift 2;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL"
+
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if wget -q -O - "$solr_url" | grep -q -i solr; then
+    break
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Solr is still not running; giving up"
+    exit 1
+  fi
+  if (( attempts_left == 1 )); then
+    attempts=attempt
+  else
+    attempts=attempts
+  fi
+  echo "Solr is not running yet on $solr_url. $attempts_left $attempts left"
+  sleep "$wait_seconds"
+done
+echo "Solr is running on $solr_url"

--- a/8.3/slim/scripts/wait-for-zookeeper.sh
+++ b/8.3/slim/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+#
+# If no argument is provided, but a Solr-style ZK_HOST is set,
+# that will be used. If neither is provided, the default
+# name is 'solr-zookeeper-headless', to match the helm chart.
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    local port="${2:-2181}"
+    if ! echo srvr | nc "$host" "$port" > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup_arg:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup_arg=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup_arg:-}" ]; then
+  if [ -n "$ZK_HOST" ]; then
+    lookup_arg="$ZK_HOST"
+  else
+    lookup_arg=solr-zookeeper-headless
+  fi
+fi
+
+echo "Looking up '$lookup_arg'"
+# split on commas, for when a ZK_HOST string like zoo1:2181,zoo2:2181 is used
+IFS=',' read -ra lookups <<< "$lookup_arg"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  for lookup in "${lookups[@]}"; do
+    if grep -q -E "^\[[0-9].*\]" <<<"$lookup"; then
+      # looks like an IPv6 address, eg [2001:DB8::1] or [2001:DB8::1]:2181
+      # getent does not support the bracket notation, but does support IPv6 addresses
+      host=$(sed -E 's/\[(.*)\].*/\1/' <<<"$lookup")
+      port=$(sed -E 's/^\[(.*)\]:?//' <<<"$lookup")
+    else
+      # IPv4, just split on :
+      IFS=: read -ra split <<<"$lookup"
+      host="${split[0]}"
+      port="${split[1]:-}"
+    fi
+    if [[ "${VERBOSE:-}" == "yes" ]]; then
+      echo "Parsed host=$host port=${port:-}"
+    fi
+    if getent hosts "$host" > $TMP_HOSTS; then
+      while read -r ip hostname ; do
+        echo "${hostname:-}">/dev/null # consume for shellcheck
+        check_zookeeper "$ip" "$port"
+      done <$TMP_HOSTS
+    else
+      echo "Cannot find $lookup yet"
+    fi
+  done
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done
+
+# To test the parsing:
+#  bash scripts/wait-for-zookeeper.sh foo
+#  bash scripts/wait-for-zookeeper.sh 'ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2'
+#  ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2 bash scripts/wait-for-zookeeper.sh

--- a/Dockerfile-varsolr.template
+++ b/Dockerfile-varsolr.template
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -10,7 +10,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -e; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat; \
   rm -rf /var/lib/apt/lists/*
 
 ENV SOLR_USER="solr" \

--- a/TAGS
+++ b/TAGS
@@ -1,5 +1,5 @@
-8.2:8.2.0:8.2 8 latest
-8.2/slim:8.2.0-slim:8.2-slim 8-slim latest-slim
+8.2:8.2.0:8.2
+8.2/slim:8.2.0-slim:8.2-slim
 8.1:8.1.1:8.1
 8.1/slim:8.1.1-slim:8.1-slim
 8.0:8.0.0:8.0
@@ -14,3 +14,5 @@
 6.6/slim:6.6.6-slim:6.6-slim 6-slim
 5.5:5.5.5:5.5 5
 5.5/slim:5.5.5-slim:5.5-slim 5-slim
+8.3:8.3.0:8.3 8 latest
+8.3/slim:8.3.0-slim:8.3-slim 8-slim latest-slim

--- a/TAGS
+++ b/TAGS
@@ -1,3 +1,5 @@
+8.3:8.3.0:8.3 8 latest
+8.3/slim:8.3.0-slim:8.3-slim 8-slim latest-slim
 8.2:8.2.0:8.2
 8.2/slim:8.2.0-slim:8.2-slim
 8.1:8.1.1:8.1
@@ -14,5 +16,3 @@
 6.6/slim:6.6.6-slim:6.6-slim 6-slim
 5.5:5.5.5:5.5 5
 5.5/slim:5.5.5-slim:5.5-slim 5-slim
-8.3:8.3.0:8.3 8 latest
-8.3/slim:8.3.0-slim:8.3-slim 8-slim latest-slim

--- a/scripts-before8/wait-for-zookeeper.sh
+++ b/scripts-before8/wait-for-zookeeper.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    if ! echo srvr | nc "$host" 2181 > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup:-}" ]; then
+  lookup=solr-zookeeper-headless
+fi
+
+echo "Looking up '$lookup'"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  if getent hosts "$lookup" > $TMP_HOSTS; then
+    while read -r ip host ; do
+      check_zookeeper "$ip"
+    done <$TMP_HOSTS
+  else
+    echo "Cannot find $lookup yet"
+  fi
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then
+    echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done

--- a/scripts/wait-for-zookeeper.sh
+++ b/scripts/wait-for-zookeeper.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# A helper script to wait for ZooKeeper
+#
+# This script waits for a ZooKeeper master to appear.
+# It repeatedly looks up the name passed as argument
+# in the DNS using getent, and then connects to the
+# ZooKeeper admin port and uses the 'srvr' command to
+# obtain the server's status.
+# You can use this in a Kubernetes init container to
+# delay Solr pods starting until the ZooKeeper service
+# has settled down. Or you could explicitly run this in
+# the Solr container before exec'ing Solr.
+#
+# Inspired by https://github.com/helm/charts/blob/9eba7b1c80990233a68dce48f4a8fe0baf9b7fa5/incubator/solr/templates/statefulset.yaml#L60
+#
+# Usage: wait-for-zookeeper.sh [--max-attempts count] [--wait-seconds seconds] zookeeper-service-name
+#
+# If no argument is provided, but a Solr-style ZK_HOST is set,
+# that will be used. If neither is provided, the default
+# name is 'solr-zookeeper-headless', to match the helm chart.
+
+set -euo pipefail
+
+SCRIPT="$0"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+function usage {
+  echo "$1"
+  echo "Usage: $SCRIPT [--max-attempts count] [--wait-seconds seconds ] zookeeper-service-name"
+  exit 1
+}
+
+TMP_HOSTS="/tmp/hosts.$$"
+TMP_STATUS="/tmp/status.$$"
+
+function cleanup {
+    rm -f $TMP_HOSTS $TMP_STATUS
+}
+
+trap cleanup EXIT
+
+function check_zookeeper {
+    local host=$1
+    local port="${2:-2181}"
+    if ! echo srvr | nc "$host" "$port" > $TMP_STATUS; then
+        echo "Failed to get status from $host"
+        return
+    fi
+    if [ ! -s $TMP_STATUS ]; then
+        echo "No data from $ip"
+        return
+    fi
+    if grep -q 'not currently serving requests' $TMP_STATUS; then
+        echo "Node $ip is not currently serving requests"
+        return
+    fi
+    mode=$(grep "Mode: " $TMP_STATUS | sed 's/Mode: //');
+    if [ -z "$mode" ]; then
+        echo "Cannot determine mode from:"
+        cat $TMP_STATUS
+        return
+    fi
+    echo "Node $ip is a $mode"
+    if [ "$mode" = "leader" ] || [ "$mode" = "standalone" ]; then
+        echo "Done"
+        exit 0
+    fi
+}
+
+max_attempts=120
+wait_seconds=2
+while (( $# > 0 )); do
+  case "$1" in
+   --help)
+     cat <<EOM
+Usage: $SCRIPT [options] zookeeper-service-name
+
+Options:
+  --max-attempts count: number of attempts to check Solr is up. Default: $max_attempts
+  --wait-seconds seconds: number of seconds to wait between attempts. Default: $wait_seconds
+EOM
+     exit 0
+     ;;
+
+   --max-attempts)
+     max_attempts="$2";
+     shift 2;
+     ;;
+
+   --wait-seconds)
+     wait_seconds="$2";
+     shift 2;
+     ;;
+
+   *)
+    if [ -n "${lookup_arg:-}" ]; then
+      usage "Cannot specify multiple zookeeper service names"
+    fi
+    lookup_arg=$1;
+    shift;
+    break;
+    ;;
+
+  esac
+done
+
+grep -q -E '^[0-9]+$' <<<"$max_attempts" || usage "--max-attempts $max_attempts: not a number"
+if (( max_attempts == 0 )); then
+  echo "The --max-attempts argument should be >0"
+  exit 1
+fi
+grep -q -E '^[0-9]+$' <<<"$wait_seconds" || usage "--wait-seconds $wait_seconds: not a number"
+
+if [ -z "${lookup_arg:-}" ]; then
+  if [ -n "$ZK_HOST" ]; then
+    lookup_arg="$ZK_HOST"
+  else
+    lookup_arg=solr-zookeeper-headless
+  fi
+fi
+
+echo "Looking up '$lookup_arg'"
+# split on commas, for when a ZK_HOST string like zoo1:2181,zoo2:2181 is used
+IFS=',' read -ra lookups <<< "$lookup_arg"
+((attempts_left=max_attempts))
+while (( attempts_left > 0 )); do
+  for lookup in "${lookups[@]}"; do
+    if grep -q -E "^\[[0-9].*\]" <<<"$lookup"; then
+      # looks like an IPv6 address, eg [2001:DB8::1] or [2001:DB8::1]:2181
+      # getent does not support the bracket notation, but does support IPv6 addresses
+      host=$(sed -E 's/\[(.*)\].*/\1/' <<<"$lookup")
+      port=$(sed -E 's/^\[(.*)\]:?//' <<<"$lookup")
+    else
+      # IPv4, just split on :
+      IFS=: read -ra split <<<"$lookup"
+      host="${split[0]}"
+      port="${split[1]:-}"
+    fi
+    if [[ "${VERBOSE:-}" == "yes" ]]; then
+      echo "Parsed host=$host port=${port:-}"
+    fi
+    if getent hosts "$host" > $TMP_HOSTS; then
+      while read -r ip hostname ; do
+        echo "${hostname:-}">/dev/null # consume for shellcheck
+        check_zookeeper "$ip" "$port"
+      done <$TMP_HOSTS
+    else
+      echo "Cannot find $lookup yet"
+    fi
+  done
+  (( attempts_left-- ))
+  if (( attempts_left == 0 )); then echo "Still no master found; giving up"
+    exit 1
+  fi
+  sleep "$wait_seconds"
+done
+
+# To test the parsing:
+#  bash scripts/wait-for-zookeeper.sh foo
+#  bash scripts/wait-for-zookeeper.sh 'ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2'
+#  ZK_HOST=[2001:DB8::1]:2181,[2001:DB8::1],127.0.0.1:2181,127.0.0.2 bash scripts/wait-for-zookeeper.sh

--- a/tools/update.sh
+++ b/tools/update.sh
@@ -75,13 +75,17 @@ function write_files {
         echo "Alpine is no longer supported"
         exit 1
     elif [[ "$dash_variant" = "-slim" ]]; then
-        if (( major_version == 7 && minor_version >= 3 )) || (( major_version > 7 )); then
+        if (( major_version == 8 && minor_version >= 3 )); then
+            FROM=openjdk:13-slim
+        elif (( major_version == 7 && minor_version >= 3 )) || (( major_version > 7 )); then
             FROM=openjdk:11-slim
         else
             FROM=openjdk:8-jre-slim
         fi
     elif [[ -z "$dash_variant" ]]; then
-        if (( major_version == 7 && minor_version >= 3 )) || (( major_version > 7 )); then
+        if (( major_version >= 8 && minor_version >= 3 )); then
+            FROM=openjdk:13-buster
+        elif (( major_version == 7 && minor_version >= 3 )) || (( major_version > 7 )); then
             FROM=openjdk:11-stretch
         else
             FROM=openjdk:8-jre-stretch


### PR DESCRIPTION
Add Solr 8.3
Use Java 13 from Solr 8.3
Add wait-for-zookeeper.sh script

See [Solr 8.3 announcement](http://mail-archives.apache.org/mod_mbox/lucene-solr-user/201911.mbox/%3cCAHPRk5HkA=-BNXRz0v1rMWZqu06VbBvmXPRpsY0OX0Y94d2s-Q@mail.gmail.com%3e)

Combines and supersedes https://github.com/docker-solr/docker-solr/pull/251/ and https://github.com/docker-solr/docker-solr/pull/255
Fixes https://github.com/docker-solr/docker-solr/issues/254 and https://github.com/docker-solr/docker-solr/issues/231