### PR TITLE
Run tests in parallel and native MacOS build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ upstream_versions
 tests/tests_to_run*
 mycores
 /tests/logs/*
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ downloads
 upstream_versions
 tests/tests_to_run*
 mycores
-/tests/logs/*
+/tests/logs/*.log
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 downloads
 .gnupg
 upstream_versions
-tests/tests_to_run
+tests/tests_to_run*
 mycores
+/tests/logs/*

--- a/scripts/wait-for-solr.sh
+++ b/scripts/wait-for-solr.sh
@@ -27,7 +27,7 @@ if [[ -v SOLR_PORT ]] && ! grep -E -q '^[0-9]+$' <<<"$SOLR_PORT"; then
   exit 1
 fi
 
-solr_url="http://localhost:${SOLR_PORT:-8983}"
+solr_url="http://localhost:${SOLR_PORT:-8983}/admin/info/system"
 
 while (( $# > 0 )); do
   case "$1" in

--- a/scripts/wait-for-solr.sh
+++ b/scripts/wait-for-solr.sh
@@ -27,7 +27,7 @@ if [[ -v SOLR_PORT ]] && ! grep -E -q '^[0-9]+$' <<<"$SOLR_PORT"; then
   exit 1
 fi
 
-solr_url="http://localhost:${SOLR_PORT:-8983}/admin/info/system"
+solr_url="http://localhost:${SOLR_PORT:-8983}"
 
 while (( $# > 0 )); do
   case "$1" in

--- a/tests/shared.sh
+++ b/tests/shared.sh
@@ -19,7 +19,7 @@ function container_cleanup {
 
 function wait_for_container_and_solr {
   local container_name=$1
-  wait_for_server_started $container_name 4
+  wait_for_server_started $container_name 0
 
   printf '\nWaiting for Solr...\n'
   local status=$(docker exec "$container_name" /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts 60 --wait-seconds 1)

--- a/tests/shared.sh
+++ b/tests/shared.sh
@@ -24,9 +24,6 @@ function wait_for_container_and_solr {
   printf '\nWaiting for Solr...\n'
   local status=$(docker exec "$container_name" /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts 60 --wait-seconds 1)
   echo "Got status from Solr: $status"
-  sleep 2
-  local status=$(docker exec "$container_name" /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts 60 --wait-seconds 1)
-  echo "Got status from Solr: $status"
   if ! grep -E -i -q 'Solr is running' <<<"$status"; then
     echo "Solr did not start"
     container_cleanup "$container_name"

--- a/tests/shared.sh
+++ b/tests/shared.sh
@@ -23,7 +23,11 @@ function wait_for_container_and_solr {
 
   printf '\nWaiting for Solr...\n'
   local status=$(docker exec "$container_name" /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts 60 --wait-seconds 1)
-  if ! grep -E -q 'Solr is running' <<<"$status"; then
+  echo "Got status from Solr: $status"
+  sleep 2
+  local status=$(docker exec "$container_name" /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts 60 --wait-seconds 1)
+  echo "Got status from Solr: $status"
+  if ! grep -E -i -q 'Solr is running' <<<"$status"; then
     echo "Solr did not start"
     container_cleanup "$container_name"
     exit 1

--- a/tests/shared.sh
+++ b/tests/shared.sh
@@ -68,7 +68,7 @@ function wait_for_server_started {
   sleep $sleep_time
 }
 
-function init_myvarsolr {
+function prepare_dir_to_mount {
   local userid=8983
   local folder=myvarsolr
   if [ ! -z "$1" ]; then

--- a/tests/shared.sh
+++ b/tests/shared.sh
@@ -23,7 +23,7 @@ function wait_for_container_and_solr {
 
   printf '\nWaiting for Solr...\n'
   local status=$(docker exec "$container_name" /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts 60 --wait-seconds 1)
-  echo "Got status from Solr: $status"
+#  echo "Got status from Solr: $status"
   if ! grep -E -i -q 'Solr is running' <<<"$status"; then
     echo "Solr did not start"
     container_cleanup "$container_name"

--- a/tests/shared.sh
+++ b/tests/shared.sh
@@ -87,7 +87,7 @@ function init_myvarsolr {
   # If you can't use setfacl (eg on macOS), you'll have to chown the directory to 8983, or apply world
   # write permissions.
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    # Workaround for MacOS
+    # Workaround for macOS
     sudo chmod -R 777 $folder
     sudo chown -R $userid $folder
   else

--- a/tests/shared.sh
+++ b/tests/shared.sh
@@ -4,33 +4,33 @@
 
 function container_cleanup {
   local container_name=$1
-  previous=$(docker inspect "$container_name" --format '{{.ID}}' || true)
+  previous=$(docker inspect "$container_name" --format '{{.ID}}' 2>/dev/null || true)
   if [[ -n $previous ]]; then
-    container_status=$(docker inspect --format='{{.State.Status}}' "$previous")
+    container_status=$(docker inspect --format='{{.State.Status}}' "$previous" 2>/dev/null)
     if [[ $container_status == 'running' ]]; then
       echo "killing $previous"
-      docker kill "$previous" || true
+      docker kill "$previous" 2>/dev/null || true
       sleep 2
     fi
     echo "removing $previous"
-    docker rm "$previous" || true
+    docker rm "$previous" 2>/dev/null || true
   fi
 }
 
 function wait_for_container_and_solr {
   local container_name=$1
-  TIMEOUT_SECONDS=$(( 5 * 60 ))
-  started=$(date +%s)
+  local TIMEOUT_SECONDS=$(( 5 * 60 ))
+  local started=$(date +%s)
   while /bin/true; do
     if (( $(date +%s) > started + TIMEOUT_SECONDS )); then
       echo "giving up after $TIMEOUT_SECONDS seconds"
       exit 1
     fi
     if ! docker inspect "$container_name" >/dev/null 2>&1; then
-      sleep 1
+      sleep 2
       continue;
     fi
-    container_status=$(docker inspect --format='{{.State.Status}}' "$container_name")
+    local container_status=$(docker inspect --format='{{.State.Status}}' "$container_name")
     if [[ $container_status == 'running' ]]; then
       break
     elif [[ $container_status == 'exited' ]]; then
@@ -46,7 +46,7 @@ function wait_for_container_and_solr {
   done
 
   printf '\nChecking Solr is running\n'
-  status=$(docker exec "$container_name" /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts 60 --wait-seconds 1)
+  local status=$(docker exec "$container_name" /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts 60 --wait-seconds 1)
   if ! grep -E -q 'solr is running' <<<"$status"; then
     echo "solr did not start"
     container_cleanup "$container_name"
@@ -57,16 +57,16 @@ function wait_for_container_and_solr {
 function wait_for_server_started {
   local container_name=$1
   echo "waiting for server start"
-  TIMEOUT_SECONDS=$(( 5 * 60 ))
-  started=$(date +%s)
+  local TIMEOUT_SECONDS=$(( 5 * 60 ))
+  local started=$(date +%s)
+  local log="tmp-${container_name}.log"
   while true; do
-    log="tmp-${container_name}.log"
     docker logs "$container_name" > "$log" 2>&1
     if grep -E -q '(o\.e\.j\.s\.Server Started|Started SocketConnector)' "$log" ; then
       break
     fi
 
-    container_status=$(docker inspect --format='{{.State.Status}}' "$container_name")
+    local container_status=$(docker inspect --format='{{.State.Status}}' "$container_name")
     if [[ $container_status == 'exited' ]]; then
       echo "container exited"
       exit 1
@@ -77,10 +77,36 @@ function wait_for_server_started {
       exit 1
     fi
     printf '.'
-    SLEEP_SECS=2
-    sleep $SLEEP_SECS
+    sleep 2
   done
   printf '\nserver started\n'
   rm "$log"
   sleep 4
+}
+
+function init_myvarsolr {
+  local userid=8983
+  local folder=myvarsolr
+  if [ ! -z "$1" ]; then
+    userid=$1
+  fi
+  if [ ! -z "$2" ]; then
+    folder=$2
+  fi
+  rm -fr $folder >/dev/null 2>&1
+  mkdir $folder
+  #echo "***** Created varsolr folder $PWD / $folder"
+
+  # The /var/solr mountpoint is owned by solr, so when we bind mount there our directory,
+  # owned by the current user in the host, will show as owned by solr, and our attempts
+  # to write to it as the user will fail. To deal with that, set the ACL to allow that.
+  # If you can't use setfacl (eg on macOS), you'll have to chown the directory to 8983, or apply world
+  # write permissions.
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Workaround for MacOS
+    sudo chmod -R 777 $folder
+    sudo chown -R $userid $folder
+  else
+    setfacl -m u:$userid:rwx $folder
+  fi
 }

--- a/tests/shared.sh
+++ b/tests/shared.sh
@@ -19,7 +19,7 @@ function container_cleanup {
 
 function wait_for_container_and_solr {
   local container_name=$1
-  wait_for_server_started $container_name 1
+  wait_for_server_started $container_name 4
 
   printf '\nWaiting for Solr...\n'
   local status=$(docker exec "$container_name" /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts 60 --wait-seconds 1)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -26,14 +26,18 @@ else
 fi
 
 echo "Running all tests for $tag"
-find "$test_dir" -mindepth 1 -maxdepth 1 -type d | sed -E -e 's/^\.\///' > tests_to_run
+tag_norm='tests_to_run_'$(echo "$tag" | tr ':/-.' '_')
+
+find "$test_dir" -mindepth 1 -maxdepth 1 -type d | sed -E -e 's/^\.\///' > "$tag_norm"
 while read  -r d; do
   if [ -f "$d/test.sh" ]; then
     echo "Starting $d/test.sh $tag"
+#    if [[ "$d" == "tests-before8/init_solr_home" ]]; then
     (cd "$d"; ./test.sh "$tag")
+#    fi
     echo "Finished $d/test.sh $tag"
     echo
   fi
-done < tests_to_run
-rm tests_to_run
+done < "$tag_norm"
+rm "$tag_norm"
 echo "Completed all tests for $tag"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -32,9 +32,7 @@ find "$test_dir" -mindepth 1 -maxdepth 1 -type d | sed -E -e 's/^\.\///' > "$tag
 while read  -r d; do
   if [ -f "$d/test.sh" ]; then
     echo "Starting $d/test.sh $tag"
-#    if [[ "$d" == "tests-8/empty-varsolr-vol-ramdomuser-rootgroup" ]]; then
     (cd "$d"; ./test.sh "$tag")
-#    fi
     echo "Finished $d/test.sh $tag"
     echo
   fi

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -26,7 +26,7 @@ else
 fi
 
 echo "Running all tests for $tag"
-tag_norm='tests_to_run_'$(echo "$tag" | tr ':/-.' '_')
+tag_norm='tests_to_run_'$(echo "$tag" | tr ':/-' '_')
 
 find "$test_dir" -mindepth 1 -maxdepth 1 -type d | sed -E -e 's/^\.\///' > "$tag_norm"
 while read  -r d; do

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -26,16 +26,13 @@ else
 fi
 
 echo "Running all tests for $tag"
-tag_norm='tests_to_run_'$(echo "$tag" | tr ':/-' '_')
 
-find "$test_dir" -mindepth 1 -maxdepth 1 -type d | sed -E -e 's/^\.\///' > "$tag_norm"
-while read  -r d; do
+for d in $(find "$test_dir" -mindepth 1 -maxdepth 1 -type d | sed -E -e 's/^\.\///'); do
   if [ -f "$d/test.sh" ]; then
     echo "Starting $d/test.sh $tag"
     (cd "$d"; ./test.sh "$tag")
     echo "Finished $d/test.sh $tag"
     echo
   fi
-done < "$tag_norm"
-rm "$tag_norm"
+done
 echo "Completed all tests for $tag"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -32,7 +32,7 @@ find "$test_dir" -mindepth 1 -maxdepth 1 -type d | sed -E -e 's/^\.\///' > "$tag
 while read  -r d; do
   if [ -f "$d/test.sh" ]; then
     echo "Starting $d/test.sh $tag"
-#    if [[ "$d" == "tests-before8/init_solr_home" ]]; then
+#    if [[ "$d" == "tests-8/empty-varsolr-vol-ramdomuser-rootgroup" ]]; then
     (cd "$d"; ./test.sh "$tag")
 #    fi
     echo "Finished $d/test.sh $tag"

--- a/tests/tests-8/create_core/test.sh
+++ b/tests/tests-8/create_core/test.sh
@@ -28,7 +28,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/create_core/test.sh
+++ b/tests/tests-8/create_core/test.sh
@@ -24,11 +24,11 @@ container_cleanup "$container_name"
 echo "Running $container_name"
 docker run --name "$container_name" -d "$tag" solr-create -c gettingstarted
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/create_core_exec/test.sh
+++ b/tests/tests-8/create_core_exec/test.sh
@@ -31,7 +31,7 @@ docker exec --user=solr "$container_name" bin/solr create_core -c gettingstarted
 sleep 5
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/create_core_exec/test.sh
+++ b/tests/tests-8/create_core_exec/test.sh
@@ -24,14 +24,13 @@ container_cleanup "$container_name"
 echo "Running $container_name"
 docker run --name "$container_name" -d "$tag"
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Creating core"
 docker exec --user=solr "$container_name" bin/solr create_core -c gettingstarted
-sleep 5
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/create_core_randomuser_rootgroup/test.sh
+++ b/tests/tests-8/create_core_randomuser_rootgroup/test.sh
@@ -26,11 +26,11 @@ container_cleanup "$container_name"
 echo "Running $container_name"
 docker run --user 7777:0 --name "$container_name" -d "$tag" solr-create -c gettingstarted
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/create_core_randomuser_rootgroup/test.sh
+++ b/tests/tests-8/create_core_randomuser_rootgroup/test.sh
@@ -30,7 +30,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/demo-tini/test.sh
+++ b/tests/tests-8/demo-tini/test.sh
@@ -34,7 +34,7 @@ if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
 fi
 
 data=$(docker exec --user=solr "$container_name" pgrep tini)
-echo $data
+echo "$data"
 
 #container_cleanup "$container_name"
 

--- a/tests/tests-8/demo-tini/test.sh
+++ b/tests/tests-8/demo-tini/test.sh
@@ -24,7 +24,7 @@ container_cleanup "$container_name"
 echo "Running $container_name"
 docker run --name "$container_name" -d -e TINI=yes "$tag" "solr-demo"
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/demo/select?q=id%3Adell')

--- a/tests/tests-8/demo/test.sh
+++ b/tests/tests-8/demo/test.sh
@@ -24,7 +24,7 @@ container_cleanup "$container_name"
 echo "Running $container_name"
 docker run --name "$container_name" -d "$tag" "solr-demo"
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/demo/select?q=id%3Adell')

--- a/tests/tests-8/empty-varsolr-dir-ramdomuser-rootgroup/test.sh
+++ b/tests/tests-8/empty-varsolr-dir-ramdomuser-rootgroup/test.sh
@@ -23,21 +23,13 @@ echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
-rm -fr myvarsolr
-mkdir myvarsolr
-
-# The /var/solr mountpoint is owned by solr, so when we bind mount there our directory,
-# owned by the current user in the host, will show as owned by solr, and our attempts
-# to write to it as the user will fail. To deal with that, set the ACL to allow that.
-# If you can't use setfacl (eg on macOS), you'll have to chown the directory to 8983, or apply world
-# write permissions.
-setfacl -m u:7777:rwx myvarsolr
-#getfacl myvarsolr
+myvarsolr="myvarsolr-${container_name}"
+init_myvarsolr 7777 $myvarsolr
 
 echo "Running $container_name"
 docker run \
   --user 7777:0 \
-  -v "$PWD/myvarsolr:/var/solr" \
+  -v "$PWD/$myvarsolr:/var/solr" \
   --name "$container_name" \
   -d "$tag" solr-precreate getting-started
 
@@ -45,7 +37,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
@@ -60,9 +52,9 @@ container_cleanup "$container_name"
 # remove the solr-owned files from inside a container
 docker run --rm -e VERBOSE=yes \
   --user root \
-  -v "$PWD/myvarsolr:/myvarsolr" "$tag" \
+  -v "$PWD/$myvarsolr:/myvarsolr" "$tag" \
   bash -c "rm -fr /myvarsolr/*"
 
-rm -fr myvarsolr
+rm -fr $myvarsolr
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-dir-ramdomuser-rootgroup/test.sh
+++ b/tests/tests-8/empty-varsolr-dir-ramdomuser-rootgroup/test.sh
@@ -33,11 +33,11 @@ docker run \
   --name "$container_name" \
   -d "$tag" solr-precreate getting-started
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/empty-varsolr-dir-ramdomuser-rootgroup/test.sh
+++ b/tests/tests-8/empty-varsolr-dir-ramdomuser-rootgroup/test.sh
@@ -24,7 +24,7 @@ container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
-init_myvarsolr 7777 $myvarsolr
+prepare_dir_to_mount 7777 $myvarsolr
 
 echo "Running $container_name"
 docker run \

--- a/tests/tests-8/empty-varsolr-dir-ramdomuser-rootgroup/test.sh
+++ b/tests/tests-8/empty-varsolr-dir-ramdomuser-rootgroup/test.sh
@@ -24,7 +24,7 @@ container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
-prepare_dir_to_mount 7777 $myvarsolr
+prepare_dir_to_mount 7777 "$myvarsolr"
 
 echo "Running $container_name"
 docker run \
@@ -55,6 +55,6 @@ docker run --rm -e VERBOSE=yes \
   -v "$PWD/$myvarsolr:/myvarsolr" "$tag" \
   bash -c "rm -fr /myvarsolr/*"
 
-rm -fr $myvarsolr
+rm -fr "$myvarsolr"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-dir-solr/test.sh
+++ b/tests/tests-8/empty-varsolr-dir-solr/test.sh
@@ -24,7 +24,7 @@ container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
-prepare_dir_to_mount 8983 $myvarsolr
+prepare_dir_to_mount 8983 "$myvarsolr"
 
 echo "Running $container_name"
 docker run \
@@ -48,14 +48,14 @@ docker exec --user=solr "$container_name" ls -l /var/solr/data
 
 container_cleanup "$container_name"
 
-ls -l $myvarsolr/
+ls -l "$myvarsolr"/
 
 # remove the solr-owned files from inside a container
 docker run --rm -e VERBOSE=yes \
   -v "$PWD/$myvarsolr:/myvarsolr" "$tag" \
   bash -c "rm -fr /myvarsolr/*"
 
-ls -l $myvarsolr/
-rm -fr $myvarsolr
+ls -l "$myvarsolr/"
+rm -fr "$myvarsolr"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-dir-solr/test.sh
+++ b/tests/tests-8/empty-varsolr-dir-solr/test.sh
@@ -32,11 +32,11 @@ docker run \
   --name "$container_name" \
   -d "$tag" solr-precreate getting-started
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/empty-varsolr-dir-solr/test.sh
+++ b/tests/tests-8/empty-varsolr-dir-solr/test.sh
@@ -23,20 +23,12 @@ echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
-rm -fr myvarsolr
-mkdir myvarsolr
-
-# The /var/solr mountpoint is owned by solr, so when we bind mount there our directory,
-# owned by the current user in the host, will show as owned by solr, and our attempts
-# to write to it as the user will fail. To deal with that, set the ACL to allow that.
-# If you can't use setfacl (eg on macOS), you'll have to chown the directory to 8983, or apply world
-# write permissions.
-setfacl -m u:8983:rwx myvarsolr
-#getfacl myvarsolr
+myvarsolr="myvarsolr-${container_name}"
+init_myvarsolr 8983 $myvarsolr
 
 echo "Running $container_name"
 docker run \
-  -v "$PWD/myvarsolr:/var/solr" \
+  -v "$PWD/$myvarsolr:/var/solr" \
   --name "$container_name" \
   -d "$tag" solr-precreate getting-started
 
@@ -44,7 +36,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
@@ -56,15 +48,14 @@ docker exec --user=solr "$container_name" ls -l /var/solr/data
 
 container_cleanup "$container_name"
 
-ls -l myvarsolr/
+ls -l $myvarsolr/
 
 # remove the solr-owned files from inside a container
 docker run --rm -e VERBOSE=yes \
-  -v "$PWD/myvarsolr:/myvarsolr" "$tag" \
+  -v "$PWD/$myvarsolr:/myvarsolr" "$tag" \
   bash -c "rm -fr /myvarsolr/*"
 
-ls -l myvarsolr/
-
-rm -fr myvarsolr
+ls -l $myvarsolr/
+rm -fr $myvarsolr
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-dir-solr/test.sh
+++ b/tests/tests-8/empty-varsolr-dir-solr/test.sh
@@ -24,7 +24,7 @@ container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
-init_myvarsolr 8983 $myvarsolr
+prepare_dir_to_mount 8983 $myvarsolr
 
 echo "Running $container_name"
 docker run \

--- a/tests/tests-8/empty-varsolr-dir-user/test.sh
+++ b/tests/tests-8/empty-varsolr-dir-user/test.sh
@@ -23,19 +23,12 @@ echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
-rm -fr myvarsolr
-mkdir myvarsolr
-
-# The /var/solr mountpoint is owned by solr, so when we bind mount our directory,
-# owned by the current user in the host, it will show in the container as owned by solr, and our attempts
-# to write to it as the current user will fail. To deal with that, set the ACL to allow that.
-# If you can't use setfacl, you'll have to chown the directory to 8983, or apply world
-# write permissions
-setfacl -m u:8983:rwx myvarsolr
+myvarsolr="myvarsolr-${container_name}"
+init_myvarsolr 8983 $myvarsolr
 
 echo "Running $container_name"
 docker run \
-  -v "$PWD/myvarsolr:/var/solr" \
+  -v "$PWD/$myvarsolr:/var/solr" \
   --name "$container_name" \
   -u "$(id -u):$(id -g)" \
   -d "$tag" solr-precreate getting-started
@@ -44,7 +37,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
@@ -57,9 +50,9 @@ docker exec --user="$(id -u)" "$container_name" ls -lR /var/solr/data
 container_cleanup "$container_name"
 
 docker run --rm --user 0:0 -d -e VERBOSE=yes \
-  -v "$PWD/myvarsolr:/myvarsolr" "$tag" \
+  -v "$PWD/$myvarsolr:/myvarsolr" "$tag" \
   bash -c "chown -R $(id -u):$(id -g) /myvarsolr; ls -ld /myvarsolr"
 
-rm -fr myvarsolr
+rm -fr $myvarsolr
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-dir-user/test.sh
+++ b/tests/tests-8/empty-varsolr-dir-user/test.sh
@@ -33,11 +33,11 @@ docker run \
   -u "$(id -u):$(id -g)" \
   -d "$tag" solr-precreate getting-started
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/empty-varsolr-dir-user/test.sh
+++ b/tests/tests-8/empty-varsolr-dir-user/test.sh
@@ -24,7 +24,7 @@ container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
-prepare_dir_to_mount 8983 $myvarsolr
+prepare_dir_to_mount 8983 "$myvarsolr"
 
 echo "Running $container_name"
 docker run \
@@ -53,6 +53,6 @@ docker run --rm --user 0:0 -d -e VERBOSE=yes \
   -v "$PWD/$myvarsolr:/myvarsolr" "$tag" \
   bash -c "chown -R $(id -u):$(id -g) /myvarsolr; ls -ld /myvarsolr"
 
-rm -fr $myvarsolr
+rm -fr "$myvarsolr"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-dir-user/test.sh
+++ b/tests/tests-8/empty-varsolr-dir-user/test.sh
@@ -24,7 +24,7 @@ container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
-init_myvarsolr 8983 $myvarsolr
+prepare_dir_to_mount 8983 $myvarsolr
 
 echo "Running $container_name"
 docker run \

--- a/tests/tests-8/empty-varsolr-vol-ramdomuser-rootgroup/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-ramdomuser-rootgroup/test.sh
@@ -38,11 +38,11 @@ docker run \
   --name "$container_name" \
   -d "$tag" solr-precreate getting-started
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/empty-varsolr-vol-ramdomuser-rootgroup/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-ramdomuser-rootgroup/test.sh
@@ -25,8 +25,8 @@ container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
 
-docker volume rm $myvarsolr >/dev/null 2>&1 || true
-docker volume create $myvarsolr
+docker volume rm "$myvarsolr" >/dev/null 2>&1 || true
+docker volume create "$myvarsolr"
 
 # when we mount onto /var/solr, that will be owned by "solr"
 
@@ -53,6 +53,6 @@ docker exec --user=7777 "$container_name" ls -l /var/solr/data
 
 container_cleanup "$container_name"
 
-docker volume rm $myvarsolr
+docker volume rm "$myvarsolr"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-vol-ramdomuser-rootgroup/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-ramdomuser-rootgroup/test.sh
@@ -24,7 +24,6 @@ container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
-init_myvarsolr 8983 $myvarsolr
 
 docker volume rm $myvarsolr >/dev/null 2>&1 || true
 docker volume create $myvarsolr
@@ -55,6 +54,5 @@ docker exec --user=7777 "$container_name" ls -l /var/solr/data
 container_cleanup "$container_name"
 
 docker volume rm $myvarsolr
-rm -fr $myvarsolr
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-vol-ramdomuser-rootgroup/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-ramdomuser-rootgroup/test.sh
@@ -23,15 +23,18 @@ echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
-docker volume rm myvarsolr >/dev/null 2>&1 || true
-docker volume create myvarsolr
+myvarsolr="myvarsolr-${container_name}"
+init_myvarsolr 8983 $myvarsolr
+
+docker volume rm $myvarsolr >/dev/null 2>&1 || true
+docker volume create $myvarsolr
 
 # when we mount onto /var/solr, that will be owned by "solr"
 
 echo "Running $container_name"
 docker run \
   --user 777:0 \
-  -v "myvarsolr:/var/solr" \
+  -v "$myvarsolr:/var/solr" \
   --name "$container_name" \
   -d "$tag" solr-precreate getting-started
 
@@ -39,7 +42,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
@@ -51,6 +54,7 @@ docker exec --user=7777 "$container_name" ls -l /var/solr/data
 
 container_cleanup "$container_name"
 
-docker volume rm myvarsolr
+docker volume rm $myvarsolr
+rm -fr $myvarsolr
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-vol-solr-nocopy/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-solr-nocopy/test.sh
@@ -25,8 +25,8 @@ container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
 
-docker volume rm $myvarsolr >/dev/null 2>&1 || true
-docker volume create $myvarsolr
+docker volume rm "$myvarsolr" >/dev/null 2>&1 || true
+docker volume create "$myvarsolr"
 
 # with nocopy, the /var/solr ends up owned by root, so we need to chown it first
 
@@ -58,6 +58,6 @@ docker exec --user=solr "$container_name" ls -l /var/solr/data
 
 container_cleanup "$container_name"
 
-docker volume rm $myvarsolr
+docker volume rm "$myvarsolr"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-vol-solr-nocopy/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-solr-nocopy/test.sh
@@ -24,7 +24,6 @@ container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
-init_myvarsolr 8983 $myvarsolr
 
 docker volume rm $myvarsolr >/dev/null 2>&1 || true
 docker volume create $myvarsolr
@@ -60,6 +59,5 @@ docker exec --user=solr "$container_name" ls -l /var/solr/data
 container_cleanup "$container_name"
 
 docker volume rm $myvarsolr
-rm -fr $myvarsolr
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-vol-solr-nocopy/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-solr-nocopy/test.sh
@@ -43,11 +43,11 @@ docker run \
   --name "$container_name" \
   -d "$tag" solr-precreate getting-started
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/empty-varsolr-vol-solr/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-solr/test.sh
@@ -37,11 +37,11 @@ docker run \
   --name "$container_name" \
   -d "$tag" solr-precreate getting-started
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/empty-varsolr-vol-solr/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-solr/test.sh
@@ -24,7 +24,6 @@ container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
-init_myvarsolr 8983 $myvarsolr
 
 docker volume rm $myvarsolr >/dev/null 2>&1 || true
 docker volume create $myvarsolr
@@ -54,6 +53,5 @@ docker exec --user=solr "$container_name" ls -l /var/solr/data
 container_cleanup "$container_name"
 
 docker volume rm $myvarsolr
-rm -fr $myvarsolr
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-vol-solr/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-solr/test.sh
@@ -25,8 +25,8 @@ container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
 
-docker volume rm $myvarsolr >/dev/null 2>&1 || true
-docker volume create $myvarsolr
+docker volume rm "$myvarsolr" >/dev/null 2>&1 || true
+docker volume create "$myvarsolr"
 
 # when we mount onto /var/solr, that will be owned by "solr"
 
@@ -52,6 +52,6 @@ docker exec --user=solr "$container_name" ls -l /var/solr/data
 
 container_cleanup "$container_name"
 
-docker volume rm $myvarsolr
+docker volume rm "$myvarsolr"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-vol-solr/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-solr/test.sh
@@ -23,14 +23,17 @@ echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
-docker volume rm myvarsolr >/dev/null 2>&1 || true
-docker volume create myvarsolr
+myvarsolr="myvarsolr-${container_name}"
+init_myvarsolr 8983 $myvarsolr
+
+docker volume rm $myvarsolr >/dev/null 2>&1 || true
+docker volume create $myvarsolr
 
 # when we mount onto /var/solr, that will be owned by "solr"
 
 echo "Running $container_name"
 docker run \
-  -v "myvarsolr:/var/solr" \
+  -v "$myvarsolr:/var/solr" \
   --name "$container_name" \
   -d "$tag" solr-precreate getting-started
 
@@ -38,7 +41,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
@@ -50,6 +53,7 @@ docker exec --user=solr "$container_name" ls -l /var/solr/data
 
 container_cleanup "$container_name"
 
-docker volume rm myvarsolr
+docker volume rm $myvarsolr
+rm -fr $myvarsolr
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-vol-user/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-user/test.sh
@@ -25,8 +25,8 @@ container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
 
-docker volume rm $myvarsolr >/dev/null 2>&1 || true
-docker volume create $myvarsolr
+docker volume rm "$myvarsolr" >/dev/null 2>&1 || true
+docker volume create "$myvarsolr"
 
 # when we mount onto /var/solr, it will be owned by "solr", and it will copy
 # the solr-owned directories and files from the container filesystem onto the
@@ -59,6 +59,6 @@ fi
 
 container_cleanup "$container_name"
 
-docker volume rm $myvarsolr
+docker volume rm "$myvarsolr"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-vol-user/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-user/test.sh
@@ -60,6 +60,7 @@ fi
 container_cleanup "$container_name"
 
 docker volume rm $myvarsolr
+
 rm -fr $myvarsolr
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-vol-user/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-user/test.sh
@@ -45,11 +45,11 @@ docker run \
   -u "$(id -u):$(id -g)" \
   -d "$tag" solr-precreate getting-started
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/empty-varsolr-vol-user/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-user/test.sh
@@ -23,8 +23,10 @@ echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
-docker volume rm myvarsolr >/dev/null 2>&1 || true
-docker volume create myvarsolr
+myvarsolr="myvarsolr-${container_name}"
+
+docker volume rm $myvarsolr >/dev/null 2>&1 || true
+docker volume create $myvarsolr
 
 # when we mount onto /var/solr, it will be owned by "solr", and it will copy
 # the solr-owned directories and files from the container filesystem onto the
@@ -32,13 +34,13 @@ docker volume create myvarsolr
 # setfacl to allow our user to write.
 # If you don't have setfacl then run as root and do: chown -R $(id -u):$(id -g) /var/solr
 docker run \
-  -v "myvarsolr:/var/solr" \
+  -v "$myvarsolr:/var/solr" \
   --rm \
   "$tag" bash -c "setfacl -R -m u:$(id -u):rwx /var/solr"
 
-echo "Running $container_name"
+echo "Running $container_name as $(id -u):$(id -g)"
 docker run \
-  -v "myvarsolr:/var/solr" \
+  -v "$myvarsolr:/var/solr" \
   --name "$container_name" \
   -u "$(id -u):$(id -g)" \
   -d "$tag" solr-precreate getting-started
@@ -47,7 +49,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c getting-started example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/getting-started/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
@@ -57,6 +59,7 @@ fi
 
 container_cleanup "$container_name"
 
-docker volume rm myvarsolr
+docker volume rm $myvarsolr
+rm -fr $myvarsolr
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/empty-varsolr-vol-user/test.sh
+++ b/tests/tests-8/empty-varsolr-vol-user/test.sh
@@ -61,6 +61,4 @@ container_cleanup "$container_name"
 
 docker volume rm $myvarsolr
 
-rm -fr $myvarsolr
-
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/gosu/test.sh
+++ b/tests/tests-8/gosu/test.sh
@@ -5,7 +5,7 @@
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   # TODO: Fix this test on Mac
-  echo "WARNING: Ignoring test 'gosu' on MacOS"
+  echo "WARNING: Ignoring test 'gosu' on macOS"
   exit 0
 fi
 

--- a/tests/tests-8/gosu/test.sh
+++ b/tests/tests-8/gosu/test.sh
@@ -82,6 +82,6 @@ docker run --rm --user 0:0 -d -e VERBOSE=yes \
   -v "$PWD/$myvarsolr:/myvarsolr" "$tag" \
   bash -c "chown -R $(id -u):$(id -g) /myvarsolr; ls -ld /myvarsolr"
 
-rm -fr $myvarsolr
+rm -fr "$myvarsolr"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/gosu/test.sh
+++ b/tests/tests-8/gosu/test.sh
@@ -31,7 +31,7 @@ container_name='test_'$(echo "$tag" | tr ':/-' '_')
 
 cd "$TEST_DIR"
 myvarsolr="myvarsolr-${container_name}"
-init_myvarsolr 8983 $myvarsolr
+prepare_dir_to_mount 8983 $myvarsolr
 
 echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"

--- a/tests/tests-8/gosu/test.sh
+++ b/tests/tests-8/gosu/test.sh
@@ -41,11 +41,11 @@ docker run --user 0:0 --name "$container_name" -d -e VERBOSE=yes \
   -v "$PWD/$myvarsolr:/var/solr" "$tag" \
   bash -c "chown -R solr:solr /var/solr; touch /var/solr/root_was_here; exec gosu solr:solr solr-precreate gettingstarted"
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/initdb/test.sh
+++ b/tests/tests-8/initdb/test.sh
@@ -23,17 +23,18 @@ echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"
 
 cd "$TEST_DIR"
-rm -fr initdb.d
-mkdir initdb.d
-cat > initdb.d/create-was-here.sh <<EOM
+initdb="initdb-$container_name"
+init_myvarsolr 8983 $initdb
+
+cat > $initdb/create-was-here.sh <<EOM
 touch /var/solr/initdb-was-here
 EOM
-cat > initdb.d/ignore-me <<EOM
+cat > $initdb/ignore-me <<EOM
 touch /var/solr/should-not-be
 EOM
 
 echo "Running $container_name"
-docker run --name "$container_name" -d -e VERBOSE=yes -v "$PWD/initdb.d:/docker-entrypoint-initdb.d" "$tag"
+docker run --name "$container_name" -d -e VERBOSE=yes -v "$PWD/$initdb:/docker-entrypoint-initdb.d" "$tag"
 
 wait_for_server_started "$container_name"
 
@@ -49,7 +50,7 @@ if [[ -n "$data" ]]; then
   exit 1
 fi
 echo "Checking docker logs"
-log=docker.log
+log=docker.log-$container_name
 if ! docker logs "$container_name" >"$log" 2>&1; then
   echo "Could not get logs for $container_name"
   exit
@@ -61,7 +62,7 @@ if ! grep -q 'ignoring /docker-entrypoint-initdb.d/ignore-me' "$log"; then
 fi
 rm "$log"
 
-rm -fr initdb.d
+rm -fr $initdb
 container_cleanup "$container_name"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/initdb/test.sh
+++ b/tests/tests-8/initdb/test.sh
@@ -24,12 +24,12 @@ container_cleanup "$container_name"
 
 cd "$TEST_DIR"
 initdb="initdb-$container_name"
-prepare_dir_to_mount 8983 $initdb
+prepare_dir_to_mount 8983 "$initdb"
 
-cat > $initdb/create-was-here.sh <<EOM
+cat > "$initdb/create-was-here.sh" <<EOM
 touch /var/solr/initdb-was-here
 EOM
-cat > $initdb/ignore-me <<EOM
+cat > "$initdb/ignore-me" <<EOM
 touch /var/solr/should-not-be
 EOM
 
@@ -62,7 +62,7 @@ if ! grep -q 'ignoring /docker-entrypoint-initdb.d/ignore-me' "$log"; then
 fi
 rm "$log"
 
-rm -fr $initdb
+rm -fr "$initdb"
 container_cleanup "$container_name"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/initdb/test.sh
+++ b/tests/tests-8/initdb/test.sh
@@ -24,7 +24,7 @@ container_cleanup "$container_name"
 
 cd "$TEST_DIR"
 initdb="initdb-$container_name"
-init_myvarsolr 8983 $initdb
+prepare_dir_to_mount 8983 $initdb
 
 cat > $initdb/create-was-here.sh <<EOM
 touch /var/solr/initdb-was-here

--- a/tests/tests-8/precreate_core/test.sh
+++ b/tests/tests-8/precreate_core/test.sh
@@ -28,7 +28,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/precreate_core/test.sh
+++ b/tests/tests-8/precreate_core/test.sh
@@ -24,11 +24,11 @@ container_cleanup "$container_name"
 echo "Running $container_name"
 docker run --name "$container_name" -d -e VERBOSE=yes "$tag" solr-precreate gettingstarted
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/precreate_core_randomuser_rootgroup/test.sh
+++ b/tests/tests-8/precreate_core_randomuser_rootgroup/test.sh
@@ -29,11 +29,11 @@ docker run \
   -e VERBOSE=yes \
   "$tag" solr-precreate gettingstarted
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/precreate_core_randomuser_rootgroup/test.sh
+++ b/tests/tests-8/precreate_core_randomuser_rootgroup/test.sh
@@ -33,7 +33,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/test_log4j/test.sh
+++ b/tests/tests-8/test_log4j/test.sh
@@ -28,11 +28,11 @@ docker run --name "$container_name" -d -e VERBOSE=yes \
   -v "$PWD/bogus-log4j2.xml:/var/solr/log4j2.xml" \
   "$tag" solr-precreate gettingstarted
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/test_log4j/test.sh
+++ b/tests/tests-8/test_log4j/test.sh
@@ -32,7 +32,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/user_volume/test.sh
+++ b/tests/tests-8/user_volume/test.sh
@@ -24,9 +24,9 @@ container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
-init_myvarsolr 8983 $myvarsolr
+prepare_dir_to_mount 8983 $myvarsolr
 mylogs="mylogs-${container_name}"
-init_myvarsolr 8983 $mylogs
+prepare_dir_to_mount 8983 $mylogs
 myconf="myconf-${container_name}"
 configsets="configsets-${container_name}"
 

--- a/tests/tests-8/user_volume/test.sh
+++ b/tests/tests-8/user_volume/test.sh
@@ -31,6 +31,7 @@ myconf="myconf-${container_name}"
 configsets="configsets-${container_name}"
 
 # create a core by hand:
+rm -fr $myconf $myvarsolr $mylogs $configsets 2>/dev/null
 docker create --name "$container_name-copier" "$tag"
 docker cp "$container_name-copier:/opt/solr/server/solr/configsets" $configsets
 docker rm "$container_name-copier"

--- a/tests/tests-8/user_volume/test.sh
+++ b/tests/tests-8/user_volume/test.sh
@@ -24,38 +24,38 @@ container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
 myvarsolr="myvarsolr-${container_name}"
-prepare_dir_to_mount 8983 $myvarsolr
+prepare_dir_to_mount 8983 "$myvarsolr"
 mylogs="mylogs-${container_name}"
-prepare_dir_to_mount 8983 $mylogs
+prepare_dir_to_mount 8983 "$mylogs"
 myconf="myconf-${container_name}"
 configsets="configsets-${container_name}"
 
 # create a core by hand:
-rm -fr $myconf $configsets 2>/dev/null
+rm -fr "$myconf" "$configsets" 2>/dev/null
 docker create --name "$container_name-copier" "$tag"
 docker cp "$container_name-copier:/opt/solr/server/solr/configsets" $configsets
 docker rm "$container_name-copier"
 for d in data_driven_schema_configs _default; do
-  if [ -d $configsets/$d ]; then
-    cp -r $configsets/$d/conf $myconf
+  if [ -d "$configsets/$d" ]; then
+    cp -r "$configsets/$d/conf" "$myconf"
     break
   fi
 done
-rm -fr $configsets
-if [ ! -d $myconf ]; then
+rm -fr "$configsets"
+if [ ! -d "$myconf" ]; then
   echo "Could not get config"
   exit 1
 fi
-if [ ! -f $myconf/solrconfig.xml ]; then
-  find $myconf
+if [ ! -f "$myconf/solrconfig.xml" ]; then
+  find "$myconf"
   echo "ERROR: no solrconfig.xml"
   exit 1
 fi
 
 # create a directory for the core
-mkdir -p $myvarsolr/data/mycore
-mkdir -p $myvarsolr/logs
-touch $myvarsolr/data/mycore/core.properties
+mkdir -p "$myvarsolr/data/mycore"
+mkdir -p "$myvarsolr/logs"
+touch "$myvarsolr/data/mycore/core.properties"
 
 echo "Running $container_name"
 docker run \
@@ -79,6 +79,6 @@ if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
 fi
 container_cleanup "$container_name"
 
-rm -fr $myconf $myvarsolr $mylogs $configsets
+rm -fr "$myconf" "$myvarsolr" "$mylogs" "$configsets"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-8/user_volume/test.sh
+++ b/tests/tests-8/user_volume/test.sh
@@ -31,7 +31,7 @@ myconf="myconf-${container_name}"
 configsets="configsets-${container_name}"
 
 # create a core by hand:
-rm -fr $myconf $myvarsolr $mylogs $configsets 2>/dev/null
+rm -fr $myconf $configsets 2>/dev/null
 docker create --name "$container_name-copier" "$tag"
 docker cp "$container_name-copier:/opt/solr/server/solr/configsets" $configsets
 docker rm "$container_name-copier"

--- a/tests/tests-8/user_volume/test.sh
+++ b/tests/tests-8/user_volume/test.sh
@@ -65,11 +65,11 @@ docker run \
   --name "$container_name" \
   -d "$tag"
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c mycore example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/mycore/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-8/user_volume/test.sh
+++ b/tests/tests-8/user_volume/test.sh
@@ -23,38 +23,44 @@ echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
+myvarsolr="myvarsolr-${container_name}"
+init_myvarsolr 8983 $myvarsolr
+mylogs="mylogs-${container_name}"
+init_myvarsolr 8983 $mylogs
+myconf="myconf-${container_name}"
+configsets="configsets-${container_name}"
+
 # create a core by hand:
-rm -fr myconf configsets
 docker create --name "$container_name-copier" "$tag"
-docker cp "$container_name-copier:/opt/solr/server/solr/configsets" configsets
+docker cp "$container_name-copier:/opt/solr/server/solr/configsets" $configsets
 docker rm "$container_name-copier"
 for d in data_driven_schema_configs _default; do
-  if [ -d configsets/$d ]; then
-    cp -r configsets/$d/conf myconf
+  if [ -d $configsets/$d ]; then
+    cp -r $configsets/$d/conf $myconf
     break
   fi
 done
-rm -fr configsets
-if [ ! -d myconf ]; then
+rm -fr $configsets
+if [ ! -d $myconf ]; then
   echo "Could not get config"
   exit 1
 fi
-if [ ! -f myconf/solrconfig.xml ]; then
-  find myconf
+if [ ! -f $myconf/solrconfig.xml ]; then
+  find $myconf
   echo "ERROR: no solrconfig.xml"
   exit 1
 fi
 
 # create a directory for the core
-rm -fr myvarsolr mylogs
-mkdir -p myvarsolr/data/mycore myvarsolr/logs mylogs
-touch myvarsolr/data/mycore/core.properties
+mkdir -p $myvarsolr/data/mycore
+mkdir -p $myvarsolr/logs
+touch $myvarsolr/data/mycore/core.properties
 
 echo "Running $container_name"
 docker run \
-  -v "$PWD/myvarsolr:/var/solr" \
-  -v "$PWD/myconf:/var/solr/data/mycore/conf:ro" \
-  -v "$PWD/mylogs:/var/solr/logs" \
+  -v "$PWD/$myvarsolr:/var/solr" \
+  -v "$PWD/$myconf:/var/solr/data/mycore/conf:ro" \
+  -v "$PWD/$mylogs:/var/solr/logs" \
   --user "$(id -u):$(id -g)" \
   --name "$container_name" \
   -d "$tag"
@@ -63,7 +69,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c mycore example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/mycore/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
@@ -72,6 +78,6 @@ if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
 fi
 container_cleanup "$container_name"
 
-rm -fr myconf myvarsolr mylogs
+rm -fr $myconf $myvarsolr $mylogs $configsets
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-before8/create_core/test.sh
+++ b/tests/tests-before8/create_core/test.sh
@@ -28,7 +28,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-before8/create_core/test.sh
+++ b/tests/tests-before8/create_core/test.sh
@@ -24,11 +24,11 @@ container_cleanup "$container_name"
 echo "Running $container_name"
 docker run --name "$container_name" -d "$tag" solr-create -c gettingstarted
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-before8/create_core_exec/test.sh
+++ b/tests/tests-before8/create_core_exec/test.sh
@@ -31,7 +31,7 @@ docker exec --user=solr "$container_name" bin/solr create_core -c gettingstarted
 sleep 5
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-before8/create_core_exec/test.sh
+++ b/tests/tests-before8/create_core_exec/test.sh
@@ -24,14 +24,14 @@ container_cleanup "$container_name"
 echo "Running $container_name"
 docker run --name "$container_name" -d "$tag"
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Creating core"
 docker exec --user=solr "$container_name" bin/solr create_core -c gettingstarted
-sleep 5
+sleep 3
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-before8/demo/test.sh
+++ b/tests/tests-before8/demo/test.sh
@@ -24,7 +24,7 @@ container_cleanup "$container_name"
 echo "Running $container_name"
 docker run --name "$container_name" -d "$tag" "solr-demo"
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/demo/select?q=id%3Adell')

--- a/tests/tests-before8/gosu/test.sh
+++ b/tests/tests-before8/gosu/test.sh
@@ -3,6 +3,12 @@
 # A simple test of gosu. We create a mycores, and chown it
 #
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # TODO: Fix this test on Mac
+  echo "WARNING: Ignoring test 'gosu' on MacOS"
+  exit 0
+fi
+
 set -euo pipefail
 
 TEST_DIR="$(dirname -- "$(readlink -f "${BASH_SOURCE-$0}")")"

--- a/tests/tests-before8/gosu/test.sh
+++ b/tests/tests-before8/gosu/test.sh
@@ -31,7 +31,7 @@ container_name='test_'$(echo "$tag" | tr ':/-' '_')
 
 cd "$TEST_DIR"
 mycores="mycores-${container_name}"
-init_myvarsolr 8983 $mycores
+prepare_dir_to_mount 8983 $mycores
 
 echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"

--- a/tests/tests-before8/gosu/test.sh
+++ b/tests/tests-before8/gosu/test.sh
@@ -5,7 +5,7 @@
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   # TODO: Fix this test on Mac
-  echo "WARNING: Ignoring test 'gosu' on MacOS"
+  echo "WARNING: Ignoring test 'gosu' on macOS"
   exit 0
 fi
 

--- a/tests/tests-before8/gosu/test.sh
+++ b/tests/tests-before8/gosu/test.sh
@@ -24,22 +24,22 @@ echo "Test $TEST_DIR $tag"
 container_name='test_'$(echo "$tag" | tr ':/-' '_')
 
 cd "$TEST_DIR"
-rm -fr mycores
-mkdir mycores
+mycores="mycores-${container_name}"
+init_myvarsolr 8983 $mycores
 
 echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"
 
 echo "Running $container_name"
 docker run --user 0:0 --name "$container_name" -d -e VERBOSE=yes \
-  -v  "$PWD/mycores:/opt/solr/server/solr/mycores" "$tag" \
+  -v  "$PWD/$mycores:/opt/solr/server/solr/mycores" "$tag" \
   bash -c "chown -R solr:solr /opt/solr/server/solr/mycores; touch /opt/solr/server/solr/mycores/root_was_here; exec gosu solr:solr solr-precreate gettingstarted"
 
 wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
@@ -49,30 +49,30 @@ fi
 container_cleanup "$container_name"
 
 # check test file was created by root
-if [[ ! -f mycores/root_was_here ]]; then
-  echo "Missing mycores/root_was_here"
+if [[ ! -f $mycores/root_was_here ]]; then
+  echo "Missing $mycores/root_was_here"
   exit 1
 fi
-if [[ "$(stat -c %U mycores/root_was_here)" != root ]]; then
-  echo "tmp/f is owned by $(stat -c %U mycores/root_was_here)"
+if [[ "$(stat -c %U $mycores/root_was_here)" != root ]]; then
+  echo "tmp/f is owned by $(stat -c %U $mycores/root_was_here)"
   exit 1
 fi
 
 # check core is created by solr
-if [[ ! -f mycores/gettingstarted/core.properties ]]; then
-  echo "Missing mycores/gettingstarted/core.properties"
+if [[ ! -f $mycores/gettingstarted/core.properties ]]; then
+  echo "Missing $mycores/gettingstarted/core.properties"
   exit 1
 fi
-if [[ "$(stat -c %u mycores/gettingstarted/core.properties)" != 8983 ]]; then
-  echo "mycores/gettingstarted/core.properties is owned by $(stat -c %u mycores/gettingstarted/core.properties)"
+if [[ "$(stat -c %u $mycores/gettingstarted/core.properties)" != 8983 ]]; then
+  echo "$mycores/gettingstarted/core.properties is owned by $(stat -c %u mycores/gettingstarted/core.properties)"
   exit 1
 fi
 
 # chown it back
 docker run --rm --user 0:0 -d -e VERBOSE=yes \
-  -v "$PWD/mycores:/opt/solr/server/solr/mycores" "$tag" \
+  -v "$PWD/$mycores:/opt/solr/server/solr/mycores" "$tag" \
   bash -c "chown -R $(id -u):$(id -g) /opt/solr/server/solr/mycores; ls -ld /opt/solr/server/solr/mycores"
 
-rm -fr mycores
+rm -fr $mycores
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-before8/gosu/test.sh
+++ b/tests/tests-before8/gosu/test.sh
@@ -41,11 +41,11 @@ docker run --user 0:0 --name "$container_name" -d -e VERBOSE=yes \
   -v  "$PWD/$mycores:/opt/solr/server/solr/mycores" "$tag" \
   bash -c "chown -R solr:solr /opt/solr/server/solr/mycores; touch /opt/solr/server/solr/mycores/root_was_here; exec gosu solr:solr solr-precreate gettingstarted"
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-before8/init_solr_home/test.sh
+++ b/tests/tests-before8/init_solr_home/test.sh
@@ -36,7 +36,7 @@ mkdir "$myvarsolr/lost+found"
 chmod a+w $myvarsolr
 docker run --name "$container_name" -d -v "$PWD/$myvarsolr:/mysolrhome" -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes -d "$tag" "solr-demo"
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -O - 'http://localhost:8983/solr/demo/select?q=id%3Adell')

--- a/tests/tests-before8/init_solr_home/test.sh
+++ b/tests/tests-before8/init_solr_home/test.sh
@@ -23,16 +23,18 @@ container_name='test_'$(echo "$tag" | tr ':/-' '_')
 
 container_cleanup "$container_name"
 
+myvarsolr="myvarsolr-${container_name}"
+
 echo "Running $container_name"
-if [ -d mysolrhome ]; then
-  docker run --rm -v "$PWD/mysolrhome:/mysolrhome" "$tag" bash -c "rm -fr /mysolrhome/*"
-  rm -fr mysolrhome
+if [ -d $myvarsolr ]; then
+  docker run --rm -v "$PWD/$myvarsolr:/mysolrhome" "$tag" bash -c "rm -fr /mysolrhome/*"
 fi
 
-mkdir mysolrhome
-mkdir mysolrhome/lost+found
-chmod a+w mysolrhome
-docker run --name "$container_name" -d -v "$PWD/mysolrhome:/mysolrhome" -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes -d "$tag" "solr-demo"
+init_myvarsolr 8983 $myvarsolr
+
+mkdir "$myvarsolr/lost+found"
+chmod a+w $myvarsolr
+docker run --name "$container_name" -d -v "$PWD/$myvarsolr:/mysolrhome" -e SOLR_HOME=/mysolrhome -e INIT_SOLR_HOME=yes -d "$tag" "solr-demo"
 
 wait_for_server_started "$container_name"
 
@@ -46,7 +48,7 @@ echo "Data loaded OK"
 
 container_cleanup "$container_name"
 
-docker run --rm -v "$PWD/mysolrhome:/mysolrhome" "$tag" bash -c "rm -fr /mysolrhome/*"
-rmdir mysolrhome
+docker run --rm -v "$PWD/$myvarsolr:/mysolrhome" "$tag" bash -c "rm -fr /mysolrhome/*"
+rmdir $myvarsolr
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-before8/init_solr_home/test.sh
+++ b/tests/tests-before8/init_solr_home/test.sh
@@ -30,7 +30,7 @@ if [ -d $myvarsolr ]; then
   docker run --rm -v "$PWD/$myvarsolr:/mysolrhome" "$tag" bash -c "rm -fr /mysolrhome/*"
 fi
 
-init_myvarsolr 8983 $myvarsolr
+prepare_dir_to_mount 8983 $myvarsolr
 
 mkdir "$myvarsolr/lost+found"
 chmod a+w $myvarsolr

--- a/tests/tests-before8/init_solr_home_volume/test.sh
+++ b/tests/tests-before8/init_solr_home_volume/test.sh
@@ -30,7 +30,7 @@ echo "Running $container_name"
 
 docker run --name "$container_name" -d -v "$VOLUME_NAME:/opt/mysolrhome" -e SOLR_HOME=/opt/mysolrhome -e INIT_SOLR_HOME=yes -d "$tag" "solr-demo"
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -O - 'http://localhost:8983/solr/demo/select?q=id%3Adell')

--- a/tests/tests-before8/initdb/test.sh
+++ b/tests/tests-before8/initdb/test.sh
@@ -24,7 +24,7 @@ container_cleanup "$container_name"
 
 cd "$TEST_DIR"
 initdb="initdb-$container_name"
-init_myvarsolr 8983 $initdb
+prepare_dir_to_mount 8983 $initdb
 
 cat > $initdb/create-was-here.sh <<EOM
 touch /opt/docker-solr/initdb-was-here

--- a/tests/tests-before8/initdb/test.sh
+++ b/tests/tests-before8/initdb/test.sh
@@ -23,17 +23,18 @@ echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"
 
 cd "$TEST_DIR"
-rm -fr initdb.d
-mkdir initdb.d
-cat > initdb.d/create-was-here.sh <<EOM
+initdb="initdb-$container_name"
+init_myvarsolr 8983 $initdb
+
+cat > $initdb/create-was-here.sh <<EOM
 touch /opt/docker-solr/initdb-was-here
 EOM
-cat > initdb.d/ignore-me <<EOM
+cat > $initdb/ignore-me <<EOM
 touch /opt/docker-solr/should-not-be
 EOM
 
 echo "Running $container_name"
-docker run --name "$container_name" -d -e VERBOSE=yes -v "$PWD/initdb.d:/docker-entrypoint-initdb.d" "$tag"
+docker run --name "$container_name" -d -e VERBOSE=yes -v "$PWD/$initdb:/docker-entrypoint-initdb.d" "$tag"
 
 wait_for_server_started "$container_name"
 
@@ -49,7 +50,7 @@ if [[ -n "$data" ]]; then
   exit 1
 fi
 echo "Checking docker logs"
-log=docker.log
+log=docker.log-$container_name
 if ! docker logs "$container_name" >"$log" 2>&1; then
   echo "Could not get logs for $container_name"
   exit
@@ -61,7 +62,7 @@ if ! grep -q 'ignoring /docker-entrypoint-initdb.d/ignore-me' "$log"; then
 fi
 rm "$log"
 
-rm -fr initdb.d
+rm -fr $initdb
 container_cleanup "$container_name"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-before8/precreate_core/test.sh
+++ b/tests/tests-before8/precreate_core/test.sh
@@ -28,7 +28,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-before8/precreate_core/test.sh
+++ b/tests/tests-before8/precreate_core/test.sh
@@ -24,11 +24,11 @@ container_cleanup "$container_name"
 echo "Running $container_name"
 docker run --name "$container_name" -d -e VERBOSE=yes "$tag" solr-precreate gettingstarted
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/gettingstarted/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-before8/precreate_core_solr_port/test.sh
+++ b/tests/tests-before8/precreate_core_solr_port/test.sh
@@ -26,11 +26,11 @@ container_cleanup "$container_name"
 echo "Running $container_name"
 docker run --name "$container_name" -d -e VERBOSE=yes -e SOLR_PORT="$MY_SOLR_PORT" "$tag" solr-precreate gettingstarted
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -port "$MY_SOLR_PORT" -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - "http://localhost:$MY_SOLR_PORT/solr/gettingstarted/select?q=id%3Adell")
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-before8/precreate_core_solr_port/test.sh
+++ b/tests/tests-before8/precreate_core_solr_port/test.sh
@@ -30,7 +30,7 @@ wait_for_server_started "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -port "$MY_SOLR_PORT" -c gettingstarted example/exampledocs/manufacturers.xml
-sleep 1
+sleep 5
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - "http://localhost:$MY_SOLR_PORT/solr/gettingstarted/select?q=id%3Adell")
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-before8/user_volume/test.sh
+++ b/tests/tests-before8/user_volume/test.sh
@@ -24,11 +24,11 @@ container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
 mylogs="mylogs-${container_name}"
-init_myvarsolr 8983 $mylogs
+prepare_dir_to_mount 8983 $mylogs
 myconf="myconf-${container_name}"
 configsets="configsets-${container_name}"
 mycore="mycore-${container_name}"
-init_myvarsolr 8983 $mycore
+prepare_dir_to_mount 8983 $mycore
 
 # create a core by hand:
 rm -fr $myconf $configsets 2>/dev/null

--- a/tests/tests-before8/user_volume/test.sh
+++ b/tests/tests-before8/user_volume/test.sh
@@ -77,6 +77,6 @@ if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
 fi
 container_cleanup "$container_name"
 
-rm -fr $myconf $mycore $mylogs $configsets
+rm -fr "$myconf" "$mycore" "$mylogs" "$configsets"
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tests/tests-before8/user_volume/test.sh
+++ b/tests/tests-before8/user_volume/test.sh
@@ -65,11 +65,11 @@ docker run \
   --name "$container_name" \
   -d "$tag"
 
-wait_for_server_started "$container_name"
+wait_for_container_and_solr "$container_name"
 
 echo "Loading data"
 docker exec --user=solr "$container_name" bin/post -c mycore example/exampledocs/manufacturers.xml
-sleep 5
+sleep 1
 echo "Checking data"
 data=$(docker exec --user=solr "$container_name" wget -q -O - 'http://localhost:8983/solr/mycore/select?q=id%3Adell')
 if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then

--- a/tests/tests-before8/user_volume/test.sh
+++ b/tests/tests-before8/user_volume/test.sh
@@ -30,8 +30,6 @@ configsets="configsets-${container_name}"
 mycore="mycore-${container_name}"
 init_myvarsolr 8983 $mycore
 
-rm -fr $myconf $configsets
-
 # create a core by hand:
 rm -fr $myconf $configsets 2>/dev/null
 docker create --name "$container_name-copier" "$tag"
@@ -55,7 +53,6 @@ if [ ! -f $myconf/solrconfig.xml ]; then
 fi
 
 # create a directory for the core
-rm -fr $mycore $mylogs 2>/dev/null
 touch $mycore/core.properties
 
 echo "Running $container_name"

--- a/tests/tests-before8/user_volume/test.sh
+++ b/tests/tests-before8/user_volume/test.sh
@@ -33,6 +33,7 @@ init_myvarsolr 8983 $mycore
 rm -fr $myconf $configsets
 
 # create a core by hand:
+rm -fr $myconf $configsets 2>/dev/null
 docker create --name "$container_name-copier" "$tag"
 docker cp "$container_name-copier:/opt/solr/server/solr/configsets" $configsets
 docker rm "$container_name-copier"
@@ -54,6 +55,7 @@ if [ ! -f $myconf/solrconfig.xml ]; then
 fi
 
 # create a directory for the core
+rm -fr $mycore $mylogs 2>/dev/null
 touch $mycore/core.properties
 
 echo "Running $container_name"

--- a/tests/tests-before8/user_volume/test.sh
+++ b/tests/tests-before8/user_volume/test.sh
@@ -23,12 +23,14 @@ echo "Cleaning up left-over containers from previous runs"
 container_cleanup "$container_name"
 container_cleanup "$container_name-copier"
 
-myvarsolr="myvarsolr-${container_name}"
-init_myvarsolr 8983 $myvarsolr
 mylogs="mylogs-${container_name}"
 init_myvarsolr 8983 $mylogs
 myconf="myconf-${container_name}"
 configsets="configsets-${container_name}"
+mycore="mycore-${container_name}"
+init_myvarsolr 8983 $mycore
+
+rm -fr $myconf $configsets
 
 # create a core by hand:
 docker create --name "$container_name-copier" "$tag"
@@ -52,15 +54,13 @@ if [ ! -f $myconf/solrconfig.xml ]; then
 fi
 
 # create a directory for the core
-mkdir -p $myvarsolr/data/mycore
-mkdir -p $myvarsolr/logs
-touch $myvarsolr/data/mycore/core.properties
+touch $mycore/core.properties
 
 echo "Running $container_name"
 docker run \
-  -v "$PWD/$myvarsolr:/opt/solr/server/solr/mycore" \
+  -v "$PWD/$mycore:/opt/solr/server/solr/mycore" \
   -v "$PWD/$myconf:/opt/solr/server/solr/mycore/conf:ro" \
-  -v "$PWD/$mylogs:/opt/server/logs" \
+  -v "$PWD/$mylogs:/opt/solr/server/logs" \
   --user "$(id -u):$(id -g)" \
   --name "$container_name" \
   -d "$tag"
@@ -78,6 +78,6 @@ if ! grep -E -q 'One Dell Way Round Rock, Texas 78682' <<<"$data"; then
 fi
 container_cleanup "$container_name"
 
-rm -fr $myconf $myvarsolr $mylogs $configsets
+rm -fr $myconf $mycore $mylogs $configsets
 
 echo "Test $TEST_DIR $tag succeeded"

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,10 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build a docker-solr build directory and set tags
 #
 # Usage: build.sh dir
 
 set -euo pipefail
+if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 
 if (( $# != 1 )); then

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -5,7 +5,6 @@
 # Usage: build.sh dir
 
 set -euo pipefail
-if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 
 if (( $# != 1 )); then

--- a/tools/build_all.sh
+++ b/tools/build_all.sh
@@ -1,10 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build all images
 #
 # Usage: build_all.sh
 
 set -euo pipefail
+if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 cd "$TOP_DIR"
 

--- a/tools/build_all.sh
+++ b/tools/build_all.sh
@@ -5,7 +5,6 @@
 # Usage: build_all.sh
 
 set -euo pipefail
-if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 cd "$TOP_DIR"
 

--- a/tools/build_latest.sh
+++ b/tools/build_latest.sh
@@ -5,7 +5,6 @@
 # Usage: build_latest.sh
 
 set -euo pipefail
-if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 cd "$TOP_DIR"
 

--- a/tools/build_latest.sh
+++ b/tools/build_latest.sh
@@ -1,10 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build just the latest version
 #
 # Usage: build_latest.sh
 
 set -euo pipefail
+if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 cd "$TOP_DIR"
 

--- a/tools/build_test.sh
+++ b/tools/build_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage: build_and_tesh.sh
 set -euo pipefail

--- a/tools/build_test_all.sh
+++ b/tools/build_test_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage: build_and_tesh.sh
 set -euo pipefail

--- a/tools/build_test_push.sh
+++ b/tools/build_test_push.sh
@@ -6,7 +6,6 @@ if [[ -n "${DEBUG:-}" ]]; then
   set -x
 fi
 
-if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 IMAGE_NAME="dockersolr/docker-solr"
 if (( $# != 1 )); then

--- a/tools/build_test_push.sh
+++ b/tools/build_test_push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 set -euo pipefail
 
@@ -6,6 +6,7 @@ if [[ -n "${DEBUG:-}" ]]; then
   set -x
 fi
 
+if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 IMAGE_NAME="dockersolr/docker-solr"
 if (( $# != 1 )); then

--- a/tools/check_froms.sh
+++ b/tools/check_froms.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Report which FROM lines in Dockerfiles rely on tags that no longer exist
 set -euo pipefail
+if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.."
 wget -q -O openjdk-tags.tmp https://raw.githubusercontent.com/docker-library/official-images/master/library/openjdk
 grep -E '^(Tags|SharedTags): ' openjdk-tags.tmp | sed -E 's/^(Tags|SharedTags): //' | sed 's/,/ /g' | sed -E 's/ +/ /g' | tr '[:space:]' '\n' | sort  | uniq > openjdk-tags

--- a/tools/check_froms.sh
+++ b/tools/check_froms.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Report which FROM lines in Dockerfiles rely on tags that no longer exist
 set -euo pipefail
-if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.."
 wget -q -O openjdk-tags.tmp https://raw.githubusercontent.com/docker-library/official-images/master/library/openjdk
 grep -E '^(Tags|SharedTags): ' openjdk-tags.tmp | sed -E 's/^(Tags|SharedTags): //' | sed 's/,/ /g' | sed -E 's/ +/ /g' | tr '[:space:]' '\n' | sort  | uniq > openjdk-tags

--- a/tools/push.sh
+++ b/tools/push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # push images to Docker hub
 #

--- a/tools/push_all.sh
+++ b/tools/push_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Push all images
 #
@@ -11,6 +11,7 @@ if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
   exit 1
 fi
 
+if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 cd "$TOP_DIR"
 

--- a/tools/push_all.sh
+++ b/tools/push_all.sh
@@ -11,7 +11,6 @@ if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
   exit 1
 fi
 
-if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 cd "$TOP_DIR"
 

--- a/tools/test_all.sh
+++ b/tools/test_all.sh
@@ -8,7 +8,17 @@ set -euo pipefail
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 cd "$TOP_DIR"
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  echo Need to authenticate as root to run tests on MacOS
+  sudo ls . > /dev/null
+fi
 full_version_variants=$(awk --field-separator ':' '{print $2}' < "$TOP_DIR/TAGS")
-for full_version_variant in $full_version_variants; do
-  ./tests/test.sh "$full_version_variant"
-done
+rm -rf tests/logs/*
+echo Going to execute tests for these versions: $full_version_variants
+echo Executing tests in parallell using 4 CPU cores per job
+parallel --bar --halt-on-error 1 --jobs 25% ./tests/test.sh {} <<< "$full_version_variants" ">" tests/logs/test-{}.log "2>&1"
+if [[ $? -ge 1 ]]; then
+  echo "ERROR: Some tests failed. Please check logs in tests/logs folder"
+else
+  echo "SUCCESS"
+fi

--- a/tools/test_all.sh
+++ b/tools/test_all.sh
@@ -5,7 +5,6 @@
 # Usage: test_all.sh
 
 set -euo pipefail
-if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 cd "$TOP_DIR"
 

--- a/tools/test_all.sh
+++ b/tools/test_all.sh
@@ -15,13 +15,13 @@ else
 fi
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  echo Please authenticate to run sudo on MacOS
+  echo Please authenticate to run sudo on macOS
   sudo ls . > /dev/null
 fi
 full_version_variants=$(awk --field-separator ':' '{print $2}' < "$TOP_DIR/TAGS")
-rm -rf tests/logs/*
-echo Going to execute tests for these versions: $full_version_variants
-echo Executing tests in parallell with $num_processes processes
+rm -rf tests/logs/*.log 2>/dev/null
+echo "Going to execute tests for these versions: $full_version_variants"
+echo "Executing tests in parallell with $num_processes processes"
 parallel --bar --halt-on-error 1 --jobs $num_processes ./tests/test.sh {} <<< "$full_version_variants" ">" tests/logs/test-{}.log "2>&1"
 if [[ $? -ge 1 ]]; then
   echo "ERROR: Some tests failed. Please check logs in tests/logs folder"

--- a/tools/test_all.sh
+++ b/tools/test_all.sh
@@ -1,10 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test all images (only the full version tag)
 #
 # Usage: test_all.sh
 
 set -euo pipefail
+if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 cd "$TOP_DIR"
 

--- a/tools/test_all.sh
+++ b/tools/test_all.sh
@@ -2,21 +2,27 @@
 #
 # Test all images (only the full version tag)
 #
-# Usage: test_all.sh
+# Usage: test_all.sh [num-processes]
 
 set -euo pipefail
 TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
 cd "$TOP_DIR"
 
+if [ -z ${1:-} ]; then
+  num_processes=2
+else
+  num_processes=$1
+fi
+
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  echo Need to authenticate as root to run tests on MacOS
+  echo Please authenticate to run sudo on MacOS
   sudo ls . > /dev/null
 fi
 full_version_variants=$(awk --field-separator ':' '{print $2}' < "$TOP_DIR/TAGS")
 rm -rf tests/logs/*
 echo Going to execute tests for these versions: $full_version_variants
-echo Executing tests in parallell using 4 CPU cores per job
-parallel --bar --halt-on-error 1 --jobs 25% ./tests/test.sh {} <<< "$full_version_variants" ">" tests/logs/test-{}.log "2>&1"
+echo Executing tests in parallell with $num_processes processes
+parallel --bar --halt-on-error 1 --jobs $num_processes ./tests/test.sh {} <<< "$full_version_variants" ">" tests/logs/test-{}.log "2>&1"
 if [[ $? -ge 1 ]]; then
   echo "ERROR: Some tests failed. Please check logs in tests/logs folder"
 else

--- a/tools/update.sh
+++ b/tools/update.sh
@@ -14,7 +14,6 @@ if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
   exit 1
 fi
 
-if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.."
 
 TOP_DIR=$PWD

--- a/tools/update.sh
+++ b/tools/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage: bash update.sh x.y.z
 #
@@ -14,6 +14,7 @@ if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
   exit 1
 fi
 
+if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.."
 
 TOP_DIR=$PWD

--- a/tools/write_travis.sh
+++ b/tools/write_travis.sh
@@ -2,7 +2,6 @@
 #
 # Write a Travis config file
 
-if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.." || exit 1
 
 cat <<EOM

--- a/tools/write_travis.sh
+++ b/tools/write_travis.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Write a Travis config file
 
+if [[ "$OSTYPE" == "darwin"* ]]; then alias readlink=greadlink; shopt -s expand_aliases; fi
 cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.." || exit 1
 
 cat <<EOM

--- a/update.md
+++ b/update.md
@@ -85,7 +85,7 @@ You will also need to install [bashbrew](https://github.com/docker-library/offic
 
 ```bash
 sudo apt-get update
-sudo apt-get -y install lsof procps curl wget gpg gawk shellcheck vim less git
+sudo apt-get -y install lsof procps curl wget gpg gawk shellcheck vim less git parallel
 sudo apt-get -y install docker.io
 sudo wget -nv --output-document=/usr/local/bin/bashbrew https://doi-janky.infosiftr.net/job/bashbrew/lastSuccessfulBuild/artifact/bin/bashbrew-amd64
 sudo chmod a+x /usr/local/bin/bashbrew
@@ -97,7 +97,7 @@ sudo adduser $USER docker
 Using [Homebrew](https://brew.sh/), install the necessary dependencies for MacOS:
 
 ```bash
-brew install coreutils wget gpg gawk shellcheck git bash
+brew install coreutils wget gpg gawk shellcheck git bash parallel
 brew install docker
 sudo wget -nv --output-document=/usr/local/bin/bashbrew https://doi-janky.infosiftr.net/job/bashbrew/lastSuccessfulBuild/artifact/bin/bashbrew-darwin-amd64
 sudo chmod a+x /usr/local/bin/bashbrew

--- a/update.md
+++ b/update.md
@@ -98,7 +98,7 @@ Using [Homebrew](https://brew.sh/), install the necessary dependencies for MacOS
 
 ```bash
 brew install coreutils wget gpg gawk shellcheck git bash parallel
-brew install docker
+brew cask install docker
 sudo wget -nv --output-document=/usr/local/bin/bashbrew https://doi-janky.infosiftr.net/job/bashbrew/lastSuccessfulBuild/artifact/bin/bashbrew-darwin-amd64
 sudo chmod a+x /usr/local/bin/bashbrew
 # Make gnu readlink the default. You may wish to undo this after building 

--- a/update.md
+++ b/update.md
@@ -168,10 +168,10 @@ When changing scripts in one of these, remember to review the other directory to
 To run simple automated tests against the images:
 
 ```bash
-tools/test_all.sh
+tools/test_all.sh [num-processes]
 ```
 
-Note that this runs all tests serially, and this takes a while.
+By default tests are run in 2 parallel processes. If you run more powerful hardware, you may want to allocate more resources to Docker and specify 5 or 10 parallel processes, e.g. `tools/test_all.sh 10`.
 
 To manually test a container, use the normal commands from the README, using the tag:
 

--- a/update.md
+++ b/update.md
@@ -101,6 +101,8 @@ brew install coreutils wget gpg gawk shellcheck git bash
 brew install docker
 sudo wget -nv --output-document=/usr/local/bin/bashbrew https://doi-janky.infosiftr.net/job/bashbrew/lastSuccessfulBuild/artifact/bin/bashbrew-darwin-amd64
 sudo chmod a+x /usr/local/bin/bashbrew
+# Make gnu readlink the default. You may wish to undo this after building 
+ln -s /usr/local/bin/greadlink /usr/local/bin/readlink
 ```
 
 ## Updating the docker-solr repository

--- a/update.md
+++ b/update.md
@@ -77,11 +77,11 @@ We don't typically announce the availability of new images.
 
 ## Build environment
 
-The build and test scripts are designed to run on a modern Linux.
-Your host needs to have `docker`, `git`, `wget` and `gpg` and `bash` >= 4 installed.
+The build and test scripts are designed to run on a modern Linux or Mac.
+Your host needs to have `docker`, `git`, `wget`, `gpg` and `bash` >= 4 installed.
 You will also need to install [bashbrew](https://github.com/docker-library/official-images/tree/master/bashbrew) such that it is on your `PATH`.
 
-For example, on Ubuntu you would do:
+### Setting up environment on Ubuntu
 
 ```bash
 sudo apt-get update
@@ -92,10 +92,21 @@ sudo chmod a+x /usr/local/bin/bashbrew
 sudo adduser $USER docker
 ```
 
+### Setting up environment on MacOS
+
+Using [Homebrew](https://brew.sh/), install the necessary dependencies for MacOS:
+
+```bash
+brew install coreutils wget gpg gawk shellcheck git bash
+brew install docker
+sudo wget -nv --output-document=/usr/local/bin/bashbrew https://doi-janky.infosiftr.net/job/bashbrew/lastSuccessfulBuild/artifact/bin/bashbrew-darwin-amd64
+sudo chmod a+x /usr/local/bin/bashbrew
+```
 
 ## Updating the docker-solr repository
 
-Get the docker-solr repository:
+Get the docker-solr repository. Make sure you [add your public SSH key to
+your GitHub profile](https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account) first:
 
 ```bash
 git clone git@github.com:docker-solr/docker-solr.git

--- a/update.md
+++ b/update.md
@@ -92,18 +92,23 @@ sudo chmod a+x /usr/local/bin/bashbrew
 sudo adduser $USER docker
 ```
 
-### Setting up environment on MacOS
+### Setting up environment on macOS
 
-Using [Homebrew](https://brew.sh/), install the necessary dependencies for MacOS:
+Using [Homebrew](https://brew.sh/), install the necessary dependencies for macOS
+
+Above all you need Docker :) If you don't have it you may install with `brew cask install docker`.
 
 ```bash
 brew install coreutils wget gpg gawk shellcheck git bash parallel
-brew cask install docker
 sudo wget -nv --output-document=/usr/local/bin/bashbrew https://doi-janky.infosiftr.net/job/bashbrew/lastSuccessfulBuild/artifact/bin/bashbrew-darwin-amd64
 sudo chmod a+x /usr/local/bin/bashbrew
 # Make gnu readlink the default. You may wish to undo this after building 
 ln -s /usr/local/bin/greadlink /usr/local/bin/readlink
 ```
+
+NOTE: If you don't want to symlink readlink permanently you may instead
+create a symbolic link to `/path/to/some/bin/readlink` and put that location
+first in your path when working with this build only.
 
 ## Updating the docker-solr repository
 


### PR DESCRIPTION
This PR runs tests in parallel by starting a process per version. We use GNU parallel tool for this.

It is much nicer with native macOS platform support for building the images than resolving to Vagrant, so this PR also adapts the scripts to work with MacOS, and adds documentation on how to prepare your Mac with dependencies.