### PR TITLE
Support for SOLR_DOWNLOAD_URL and other build-args

### DIFF
--- a/Dockerfile-varsolr.template
+++ b/Dockerfile-varsolr.template
@@ -127,10 +127,7 @@ RUN set -ex; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R "$SOLR_USER:0" /var/solr; \
   { command -v gpgconf; gpgconf --kill all || :; }; \
-  rm -r "$GNUPGHOME"; \
-  # Clear some variables that are of no use runtime
-  unset GOSU_KEY GOSU_VERSION TINI_KEY TINI_VERSION SOLR_USER SOLR_UID SOLR_GROUP SOLR_GID \
-        SOLR_CLOSER_URL SOLR_DIST_URL SOLR_ARCHIVE_URL SOLR_DOWNLOAD_URL SOLR_DOWNLOAD_SERVER SOLR_KEYS SOLR_SHA512
+  rm -r "$GNUPGHOME"
 
 COPY --chown=0:0 scripts /opt/docker-solr/scripts
 

--- a/Dockerfile-varsolr.template
+++ b/Dockerfile-varsolr.template
@@ -127,7 +127,10 @@ RUN set -ex; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R "$SOLR_USER:0" /var/solr; \
   { command -v gpgconf; gpgconf --kill all || :; }; \
-  rm -r "$GNUPGHOME"
+  rm -r "$GNUPGHOME"; \
+  # Clear some variables that are of no use runtime
+  unset GOSU_KEY GOSU_VERSION TINI_KEY TINI_VERSION SOLR_USER SOLR_UID SOLR_GROUP SOLR_GID \
+        SOLR_CLOSER_URL SOLR_DIST_URL SOLR_ARCHIVE_URL SOLR_DOWNLOAD_URL SOLR_DOWNLOAD_SERVER SOLR_KEYS SOLR_SHA512
 
 COPY --chown=0:0 scripts /opt/docker-solr/scripts
 
@@ -135,19 +138,6 @@ VOLUME /var/solr
 EXPOSE 8983
 WORKDIR /opt/solr
 USER $SOLR_USER
-
-# Clear some variables that are of no use runtime
-ENV SOLR_USER= \
-    SOLR_UID= \
-    SOLR_GROUP= \
-    SOLR_GID= \
-    SOLR_CLOSER_URL= \
-    SOLR_DIST_URL= \
-    SOLR_ARCHIVE_URL= \
-    SOLR_DOWNLOAD_URL= \
-    SOLR_DOWNLOAD_SERVER= \
-    SOLR_KEYS= \
-    SOLR_SHA512=
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["solr-foreground"]

--- a/Dockerfile-varsolr.template
+++ b/Dockerfile-varsolr.template
@@ -6,6 +6,7 @@ LABEL repository="https://github.com/docker-solr/docker-solr"
 
 ARG SOLR_VERSION="$REPLACE_SOLR_VERSION"
 ARG SOLR_SHA512="$REPLACE_SOLR_SHA512"
+ARG SOLR_KEYS="$REPLACE_SOLR_KEYS"
 # If specified, this will override SOLR_DOWNLOAD_SERVER and all ASF mirrors. Typically used downstream for custom builds
 ARG SOLR_DOWNLOAD_URL
 
@@ -25,7 +26,6 @@ ENV SOLR_USER="solr" \
     SOLR_CLOSER_URL="http://www.apache.org/dyn/closer.lua?filename=lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz&action=download" \
     SOLR_DIST_URL="https://www.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz" \
     SOLR_ARCHIVE_URL="https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz" \
-    SOLR_KEYS="$REPLACE_SOLR_KEYS" \
     PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH" \
     SOLR_INCLUDE=/etc/default/solr.in.sh \
     SOLR_HOME=/var/solr/data \

--- a/Dockerfile-varsolr.template
+++ b/Dockerfile-varsolr.template
@@ -4,6 +4,11 @@ FROM $REPLACE_FROM
 LABEL maintainer="Martijn Koster \"mak-docker@greenhills.co.uk\""
 LABEL repository="https://github.com/docker-solr/docker-solr"
 
+ARG SOLR_VERSION="$REPLACE_SOLR_VERSION"
+ARG SOLR_SHA512="$REPLACE_SOLR_SHA512"
+# If specified, this will override SOLR_DOWNLOAD_SERVER and all ASF mirrors. Typically used downstream for custom builds
+ARG SOLR_DOWNLOAD_URL
+
 # Override the solr download location with e.g.:
 #   docker build -t mine --build-arg SOLR_DOWNLOAD_SERVER=http://www-eu.apache.org/dist/lucene/solr .
 ARG SOLR_DOWNLOAD_SERVER
@@ -17,11 +22,9 @@ ENV SOLR_USER="solr" \
     SOLR_UID="8983" \
     SOLR_GROUP="solr" \
     SOLR_GID="8983" \
-    SOLR_VERSION="$REPLACE_SOLR_VERSION" \
-    SOLR_CLOSER_URL="http://www.apache.org/dyn/closer.lua?filename=lucene/solr/$REPLACE_SOLR_VERSION/solr-$REPLACE_SOLR_VERSION.tgz&action=download" \
-    SOLR_DIST_URL="https://www.apache.org/dist/lucene/solr/$REPLACE_SOLR_VERSION/solr-$REPLACE_SOLR_VERSION.tgz" \
-    SOLR_ARCHIVE_URL="https://archive.apache.org/dist/lucene/solr/$REPLACE_SOLR_VERSION/solr-$REPLACE_SOLR_VERSION.tgz" \
-    SOLR_SHA256="$REPLACE_SOLR_SHA256" \
+    SOLR_CLOSER_URL="http://www.apache.org/dyn/closer.lua?filename=lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz&action=download" \
+    SOLR_DIST_URL="https://www.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz" \
+    SOLR_ARCHIVE_URL="https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz" \
     SOLR_KEYS="$REPLACE_SOLR_KEYS" \
     PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH" \
     SOLR_INCLUDE=/etc/default/solr.in.sh \
@@ -76,22 +79,30 @@ RUN set -ex; \
   rm /usr/local/bin/tini.asc; \
   chmod +x /usr/local/bin/tini; \
   tini --version; \
-  if [ -n "$SOLR_DOWNLOAD_SERVER" ]; then \
+  MAX_REDIRECTS=1; \
+  if [ -n "$SOLR_DOWNLOAD_URL" ]; then \
+    # If a custom URL is defined, we download from non-ASF mirror URL and allow more redirects and skip GPG step
+    # This takes effect only if the SOLR_DOWNLOAD_URL build-arg is specified, typically in downstream Dockerfiles
+    MAX_REDIRECTS=4; \
+    SKIP_GPG_CHECK=true; \
+  elif [ -n "$SOLR_DOWNLOAD_SERVER" ]; then \
     SOLR_DOWNLOAD_URL="$SOLR_DOWNLOAD_SERVER/$SOLR_VERSION/solr-$SOLR_VERSION.tgz"; \
-    echo "downloading $SOLR_DOWNLOAD_URL"; \
-    wget -t 10 --max-redirect 1 --retry-connrefused -nv "$SOLR_DOWNLOAD_URL" -O "/opt/solr-$SOLR_VERSION.tgz" || rm -f "/opt/solr-$SOLR_VERSION.tgz"; \
   fi; \
-  for url in $SOLR_CLOSER_URL $SOLR_DIST_URL $SOLR_ARCHIVE_URL; do \
+  for url in $SOLR_DOWNLOAD_URL $SOLR_CLOSER_URL $SOLR_DIST_URL $SOLR_ARCHIVE_URL; do \
     if [ -f "/opt/solr-$SOLR_VERSION.tgz" ]; then break; fi; \
     echo "downloading $url"; \
-    if wget -t 10 --max-redirect 1 --retry-connrefused -nv "$url" -O "/opt/solr-$SOLR_VERSION.tgz"; then break; else rm -f "/opt/solr-$SOLR_VERSION.tgz"; fi; \
+    if wget -t 10 --max-redirect $MAX_REDIRECTS --retry-connrefused -nv "$url" -O "/opt/solr-$SOLR_VERSION.tgz"; then break; else rm -f "/opt/solr-$SOLR_VERSION.tgz"; fi; \
   done; \
   if [ ! -f "/opt/solr-$SOLR_VERSION.tgz" ]; then echo "failed all download attempts for solr-$SOLR_VERSION.tgz"; exit 1; fi; \
-  echo "downloading $SOLR_ARCHIVE_URL.asc"; \
-  wget -nv "$SOLR_ARCHIVE_URL.asc" -O "/opt/solr-$SOLR_VERSION.tgz.asc"; \
-  echo "$SOLR_SHA256 */opt/solr-$SOLR_VERSION.tgz" | sha256sum -c -; \
-  (>&2 ls -l "/opt/solr-$SOLR_VERSION.tgz" "/opt/solr-$SOLR_VERSION.tgz.asc"); \
-  gpg --batch --verify "/opt/solr-$SOLR_VERSION.tgz.asc" "/opt/solr-$SOLR_VERSION.tgz"; \
+  if [ -z "$SKIP_GPG_CHECK" ]; then \
+    echo "downloading $SOLR_ARCHIVE_URL.asc"; \
+    wget -nv "$SOLR_ARCHIVE_URL.asc" -O "/opt/solr-$SOLR_VERSION.tgz.asc"; \
+    echo "$SOLR_SHA512 */opt/solr-$SOLR_VERSION.tgz" | sha512sum -c -; \
+    (>&2 ls -l "/opt/solr-$SOLR_VERSION.tgz" "/opt/solr-$SOLR_VERSION.tgz.asc"); \
+    gpg --batch --verify "/opt/solr-$SOLR_VERSION.tgz.asc" "/opt/solr-$SOLR_VERSION.tgz"; \
+  else \
+    echo "Skipping GPG validation due to non-Apache build"; \
+  fi; \
   tar -C /opt --extract --file "/opt/solr-$SOLR_VERSION.tgz"; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
@@ -124,6 +135,19 @@ VOLUME /var/solr
 EXPOSE 8983
 WORKDIR /opt/solr
 USER $SOLR_USER
+
+# Clear some variables that are of no use runtime
+ENV SOLR_USER= \
+    SOLR_UID= \
+    SOLR_GROUP= \
+    SOLR_GID= \
+    SOLR_CLOSER_URL= \
+    SOLR_DIST_URL= \
+    SOLR_ARCHIVE_URL= \
+    SOLR_DOWNLOAD_URL= \
+    SOLR_DOWNLOAD_SERVER= \
+    SOLR_KEYS= \
+    SOLR_SHA512=
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["solr-foreground"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,6 +6,7 @@ LABEL repository="https://github.com/docker-solr/docker-solr"
 
 ARG SOLR_VERSION="$REPLACE_SOLR_VERSION"
 ARG SOLR_SHA512="$REPLACE_SOLR_SHA512"
+ARG SOLR_KEYS="$REPLACE_SOLR_KEYS"
 # If specified, this will override SOLR_DOWNLOAD_SERVER and all ASF mirrors. Typically used downstream for custom builds
 ARG SOLR_DOWNLOAD_URL
 
@@ -25,7 +26,6 @@ ENV SOLR_USER="solr" \
     SOLR_CLOSER_URL="http://www.apache.org/dyn/closer.lua?filename=lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz&action=download" \
     SOLR_DIST_URL="https://www.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz" \
     SOLR_ARCHIVE_URL="https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz" \
-    SOLR_KEYS="$REPLACE_SOLR_KEYS" \
     PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH"
 
 ENV GOSU_VERSION 1.11

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,6 +4,11 @@ FROM $REPLACE_FROM
 LABEL maintainer="Martijn Koster \"mak-docker@greenhills.co.uk\""
 LABEL repository="https://github.com/docker-solr/docker-solr"
 
+ARG SOLR_VERSION="$REPLACE_SOLR_VERSION"
+ARG SOLR_SHA512="$REPLACE_SOLR_SHA512"
+# If specified, this will override SOLR_DOWNLOAD_SERVER and all ASF mirrors. Typically used downstream for custom builds
+ARG SOLR_DOWNLOAD_URL
+
 # Override the solr download location with e.g.:
 #   docker build -t mine --build-arg SOLR_DOWNLOAD_SERVER=http://www-eu.apache.org/dist/lucene/solr .
 ARG SOLR_DOWNLOAD_SERVER
@@ -17,11 +22,9 @@ ENV SOLR_USER="solr" \
     SOLR_UID="8983" \
     SOLR_GROUP="solr" \
     SOLR_GID="8983" \
-    SOLR_VERSION="$REPLACE_SOLR_VERSION" \
-    SOLR_CLOSER_URL="http://www.apache.org/dyn/closer.lua?filename=lucene/solr/$REPLACE_SOLR_VERSION/solr-$REPLACE_SOLR_VERSION.tgz&action=download" \
-    SOLR_DIST_URL="https://www.apache.org/dist/lucene/solr/$REPLACE_SOLR_VERSION/solr-$REPLACE_SOLR_VERSION.tgz" \
-    SOLR_ARCHIVE_URL="https://archive.apache.org/dist/lucene/solr/$REPLACE_SOLR_VERSION/solr-$REPLACE_SOLR_VERSION.tgz" \
-    SOLR_SHA256="$REPLACE_SOLR_SHA256" \
+    SOLR_CLOSER_URL="http://www.apache.org/dyn/closer.lua?filename=lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz&action=download" \
+    SOLR_DIST_URL="https://www.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz" \
+    SOLR_ARCHIVE_URL="https://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/solr-$SOLR_VERSION.tgz" \
     SOLR_KEYS="$REPLACE_SOLR_KEYS" \
     PATH="/opt/solr/bin:/opt/docker-solr/scripts:$PATH"
 
@@ -71,22 +74,30 @@ RUN set -ex; \
   rm /usr/local/bin/tini.asc; \
   chmod +x /usr/local/bin/tini; \
   tini --version; \
-  if [ -n "$SOLR_DOWNLOAD_SERVER" ]; then \
+  MAX_REDIRECTS=1; \
+  if [ -n "$SOLR_DOWNLOAD_URL" ]; then \
+    # If a custom URL is defined, we download from non-ASF mirror URL and allow more redirects and skip GPG step
+    # This takes effect only if the SOLR_DOWNLOAD_URL build-arg is specified, typically in downstream Dockerfiles
+    MAX_REDIRECTS=4; \
+    SKIP_GPG_CHECK=true; \
+  elif [ -n "$SOLR_DOWNLOAD_SERVER" ]; then \
     SOLR_DOWNLOAD_URL="$SOLR_DOWNLOAD_SERVER/$SOLR_VERSION/solr-$SOLR_VERSION.tgz"; \
-    echo "downloading $SOLR_DOWNLOAD_URL"; \
-    wget -t 10 --max-redirect 1 --retry-connrefused -nv "$SOLR_DOWNLOAD_URL" -O "/opt/solr-$SOLR_VERSION.tgz" || rm -f "/opt/solr-$SOLR_VERSION.tgz"; \
   fi; \
-  for url in $SOLR_CLOSER_URL $SOLR_DIST_URL $SOLR_ARCHIVE_URL; do \
+  for url in $SOLR_DOWNLOAD_URL $SOLR_CLOSER_URL $SOLR_DIST_URL $SOLR_ARCHIVE_URL; do \
     if [ -f "/opt/solr-$SOLR_VERSION.tgz" ]; then break; fi; \
     echo "downloading $url"; \
-    if wget -t 10 --max-redirect 1 --retry-connrefused -nv "$url" -O "/opt/solr-$SOLR_VERSION.tgz"; then break; else rm -f "/opt/solr-$SOLR_VERSION.tgz"; fi; \
+    if wget -t 10 --max-redirect $MAX_REDIRECTS --retry-connrefused -nv "$url" -O "/opt/solr-$SOLR_VERSION.tgz"; then break; else rm -f "/opt/solr-$SOLR_VERSION.tgz"; fi; \
   done; \
   if [ ! -f "/opt/solr-$SOLR_VERSION.tgz" ]; then echo "failed all download attempts for solr-$SOLR_VERSION.tgz"; exit 1; fi; \
-  echo "downloading $SOLR_ARCHIVE_URL.asc"; \
-  wget -nv "$SOLR_ARCHIVE_URL.asc" -O "/opt/solr-$SOLR_VERSION.tgz.asc"; \
-  echo "$SOLR_SHA256 */opt/solr-$SOLR_VERSION.tgz" | sha256sum -c -; \
-  (>&2 ls -l "/opt/solr-$SOLR_VERSION.tgz" "/opt/solr-$SOLR_VERSION.tgz.asc"); \
-  gpg --batch --verify "/opt/solr-$SOLR_VERSION.tgz.asc" "/opt/solr-$SOLR_VERSION.tgz"; \
+  if [ -z "$SKIP_GPG_CHECK" ]; then \
+    echo "downloading $SOLR_ARCHIVE_URL.asc"; \
+    wget -nv "$SOLR_ARCHIVE_URL.asc" -O "/opt/solr-$SOLR_VERSION.tgz.asc"; \
+    echo "$SOLR_SHA512 */opt/solr-$SOLR_VERSION.tgz" | sha512sum -c -; \
+    (>&2 ls -l "/opt/solr-$SOLR_VERSION.tgz" "/opt/solr-$SOLR_VERSION.tgz.asc"); \
+    gpg --batch --verify "/opt/solr-$SOLR_VERSION.tgz.asc" "/opt/solr-$SOLR_VERSION.tgz"; \
+  else \
+    echo "Skipping GPG validation due to non-Apache build"; \
+  fi; \
   tar -C /opt --extract --file "/opt/solr-$SOLR_VERSION.tgz"; \
   mv "/opt/solr-$SOLR_VERSION" /opt/solr; \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
@@ -107,6 +118,19 @@ COPY --chown=solr:solr scripts /opt/docker-solr/scripts
 EXPOSE 8983
 WORKDIR /opt/solr
 USER $SOLR_USER
+
+# Clear some variables that are of no use runtime
+ENV SOLR_USER= \
+    SOLR_UID= \
+    SOLR_GROUP= \
+    SOLR_GID= \
+    SOLR_CLOSER_URL= \
+    SOLR_DIST_URL= \
+    SOLR_ARCHIVE_URL= \
+    SOLR_DOWNLOAD_URL= \
+    SOLR_DOWNLOAD_SERVER= \
+    SOLR_KEYS= \
+    SOLR_SHA512=
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["solr-foreground"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -111,10 +111,7 @@ RUN set -ex; \
   chown -R "$SOLR_USER:$SOLR_GROUP" /opt/solr /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R "$SOLR_USER:$SOLR_GROUP" /opt/mysolrhome; \
   { command -v gpgconf; gpgconf --kill all || :; }; \
-  rm -r "$GNUPGHOME"; \
-  # Clear some variables that are of no use runtime
-  unset GOSU_KEY GOSU_VERSION TINI_KEY TINI_VERSION SOLR_USER SOLR_UID SOLR_GROUP SOLR_GID \
-        SOLR_CLOSER_URL SOLR_DIST_URL SOLR_ARCHIVE_URL SOLR_DOWNLOAD_URL SOLR_DOWNLOAD_SERVER SOLR_KEYS SOLR_SHA512
+  rm -r "$GNUPGHOME"
 
 COPY --chown=solr:solr scripts /opt/docker-solr/scripts
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -111,26 +111,16 @@ RUN set -ex; \
   chown -R "$SOLR_USER:$SOLR_GROUP" /opt/solr /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R "$SOLR_USER:$SOLR_GROUP" /opt/mysolrhome; \
   { command -v gpgconf; gpgconf --kill all || :; }; \
-  rm -r "$GNUPGHOME"
+  rm -r "$GNUPGHOME"; \
+  # Clear some variables that are of no use runtime
+  unset GOSU_KEY GOSU_VERSION TINI_KEY TINI_VERSION SOLR_USER SOLR_UID SOLR_GROUP SOLR_GID \
+        SOLR_CLOSER_URL SOLR_DIST_URL SOLR_ARCHIVE_URL SOLR_DOWNLOAD_URL SOLR_DOWNLOAD_SERVER SOLR_KEYS SOLR_SHA512
 
 COPY --chown=solr:solr scripts /opt/docker-solr/scripts
 
 EXPOSE 8983
 WORKDIR /opt/solr
 USER $SOLR_USER
-
-# Clear some variables that are of no use runtime
-ENV SOLR_USER= \
-    SOLR_UID= \
-    SOLR_GROUP= \
-    SOLR_GID= \
-    SOLR_CLOSER_URL= \
-    SOLR_DIST_URL= \
-    SOLR_ARCHIVE_URL= \
-    SOLR_DOWNLOAD_URL= \
-    SOLR_DOWNLOAD_SERVER= \
-    SOLR_KEYS= \
-    SOLR_SHA512=
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["solr-foreground"]

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -4,6 +4,10 @@
 
 set -e
 
+# Clear some variables that we don't want runtime
+unset GOSU_KEY GOSU_VERSION TINI_KEY TINI_VERSION SOLR_USER SOLR_UID SOLR_GROUP SOLR_GID \
+      SOLR_CLOSER_URL SOLR_DIST_URL SOLR_ARCHIVE_URL SOLR_DOWNLOAD_URL SOLR_DOWNLOAD_SERVER SOLR_KEYS SOLR_SHA512
+
 if [[ "$VERBOSE" == "yes" ]]; then
     set -x
 fi

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -41,8 +41,18 @@ else
   cp -r "$TOP_DIR/scripts" .
 fi
 
+build_arg=""
 if [ -n "${SOLR_DOWNLOAD_SERVER:-}" ]; then
   build_arg="--build-arg SOLR_DOWNLOAD_SERVER=$SOLR_DOWNLOAD_SERVER"
+fi
+if [ -n "${SOLR_DOWNLOAD_URL:-}" ]; then
+  build_arg="$build_arg --build-arg SOLR_DOWNLOAD_URL=$SOLR_DOWNLOAD_URL"
+fi
+if [ -n "${SOLR_VERSION:-}" ]; then
+  build_arg="$build_arg --build-arg SOLR_VERSION=$SOLR_VERSION"
+fi
+if [ -n "${SOLR_SHA512:-}" ]; then
+  build_arg="$build_arg --build-arg SOLR_SHA512=$SOLR_SHA512"
 fi
 if [ "${NOCACHE:-no}" == 'yes' ]; then
   nocache_arg="--no-cache"

--- a/tools/update.sh
+++ b/tools/update.sh
@@ -101,7 +101,7 @@ function write_files {
     <"$template" sed -E \
       -e "s/FROM \\\$REPLACE_FROM/FROM $FROM/g" \
       -e "s/\\\$REPLACE_SOLR_VERSION/$full_version/g" \
-      -e "s/\\\$REPLACE_SOLR_SHA256/$SHA256/g" \
+      -e "s/\\\$REPLACE_SOLR_SHA512/$SHA512/g" \
       -e "s/\\\$REPLACE_SOLR_KEYS/$KEYS/g" \
       > "$target_dir/Dockerfile"
 
@@ -326,7 +326,7 @@ for version in "${versions[@]}"; do
     verify_signature "$full_version"
 
     # We will record a stronger SHA256, for write_files
-    SHA256=$(sha256sum "solr-$full_version.tgz" | awk '{print $1}')
+    SHA512=$(sha512sum "solr-$full_version.tgz" | awk '{print $1}')
 
     cd "$TOP_DIR"
 


### PR DESCRIPTION
The goal of this PR is to make the Dockerfiles from this project easier to use by developers, and at the same time make it more DRY. Here's a list of improvements

* Converted ENV `SOLR_VERSION` and `SOLR_SHA512` into build-args
* Using SHA512 instead of SHA256 since this is what upstream already uses
* Added new build-arg `SOLR_DOWNLOAD_URL` (#264)
  This enables downstream users to build a docker image with a custom build Solr version by also passing in the build-arg SOLR_SHA512
  In case of custom URL, we skip GPG validation as this tgz will not be signed
* We clear a bunch of env vars that are only cluttering the image runtime. This is done in `docker-entrypoint.sh` since there is no UNSETENV command

Fixes #264 