### PR TITLE
Fix generate-stackbrew-library.sh to work on macos

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Produce https://github.com/docker-library/official-images/blob/master/library/solr
 # Based on https://github.com/docker-library/httpd/blob/master/generate-stackbrew-library.sh

--- a/tools/init_macos.sh
+++ b/tools/init_macos.sh
@@ -1,0 +1,12 @@
+# Source this file to prepare a mac for running scripts
+hash greadlink 2>/dev/null || { echo >&2 "Required tool greadlink is not installed, please run 'brew install coreutils'"; exit 1; }
+hash gfind 2>/dev/null || { echo >&2 "Required tool gfind is not installed, please run 'brew install findutils'"; exit 1; }
+if [[ ! -d /tmp/docker-solr-bin ]]; then
+  mkdir -p /tmp/docker-solr-bin >/dev/null 2>&1
+  ln -s /usr/local/bin/greadlink /tmp/docker-solr-bin/readlink
+  ln -s /usr/local/bin/gfind /tmp/docker-solr-bin/find
+fi
+if [[ ! $PATH == *"docker-solr-bin"* ]]; then
+  export PATH=/tmp/docker-solr-bin:$PATH
+  echo "Configuring for macOS - ádding /tmp/docker-solr-bin first in path"
+fi

--- a/tools/init_macos.sh
+++ b/tools/init_macos.sh
@@ -8,5 +8,5 @@ if [[ ! -d /tmp/docker-solr-bin ]]; then
 fi
 if [[ ! $PATH == *"docker-solr-bin"* ]]; then
   export PATH=/tmp/docker-solr-bin:$PATH
-  echo "Configuring for macOS - ádding /tmp/docker-solr-bin first in path"
+  echo "Configuring for macOS - adding /tmp/docker-solr-bin first in path"
 fi

--- a/update.md
+++ b/update.md
@@ -97,19 +97,20 @@ sudo adduser $USER docker
 Using [Homebrew](https://brew.sh/), install the necessary dependencies for macOS
 
 Above all you need Docker :) If you don't have it you may install with `brew cask install docker`.
+You also need the GNU version of some tools.
 
 ```bash
-brew install coreutils wget gpg gawk shellcheck git bash parallel findutils
+brew install gpg  # If you don't have GPG already
+brew install git  # If you don't have git already
+brew install coreutils wget gawk shellcheck bash parallel findutils  # Other dependencies
 sudo wget -nv --output-document=/usr/local/bin/bashbrew https://doi-janky.infosiftr.net/job/bashbrew/lastSuccessfulBuild/artifact/bin/bashbrew-darwin-amd64
 sudo chmod a+x /usr/local/bin/bashbrew
-# Make gnu readlink and find the default. You may wish to undo this after building 
-ln -s /usr/local/bin/greadlink /usr/local/bin/readlink
-ln -s /usr/local/bin/gfind /usr/local/bin/find
 ```
 
-NOTE: If you don't want to symlink readlink and gfind permanently you may instead
-create symbolic links to `/path/to/some/bin/readlink` and `/path/to/some/bin/find` and put that location
-first in your path when working with this build only.
+Before you start running scripts, please run an init script that puts GNU tools first in PATH. The settings only takes effect for the current Terminal window:
+```bash
+source tools/init_macos.sh
+```
 
 ### Setting up envionment on Windows
 

--- a/update.md
+++ b/update.md
@@ -108,7 +108,7 @@ ln -s /usr/local/bin/gfind /usr/local/bin/find
 ```
 
 NOTE: If you don't want to symlink readlink and gfind permanently you may instead
-create symbolic links to `/path/to/some/bin/readlink` and `/path/to/somr/bin/find` and put that location
+create symbolic links to `/path/to/some/bin/readlink` and `/path/to/some/bin/find` and put that location
 first in your path when working with this build only.
 
 ### Setting up envionment on Windows

--- a/update.md
+++ b/update.md
@@ -99,15 +99,16 @@ Using [Homebrew](https://brew.sh/), install the necessary dependencies for macOS
 Above all you need Docker :) If you don't have it you may install with `brew cask install docker`.
 
 ```bash
-brew install coreutils wget gpg gawk shellcheck git bash parallel
+brew install coreutils wget gpg gawk shellcheck git bash parallel findutils
 sudo wget -nv --output-document=/usr/local/bin/bashbrew https://doi-janky.infosiftr.net/job/bashbrew/lastSuccessfulBuild/artifact/bin/bashbrew-darwin-amd64
 sudo chmod a+x /usr/local/bin/bashbrew
-# Make gnu readlink the default. You may wish to undo this after building 
+# Make gnu readlink and find the default. You may wish to undo this after building 
 ln -s /usr/local/bin/greadlink /usr/local/bin/readlink
+ln -s /usr/local/bin/gfind /usr/local/bin/find
 ```
 
-NOTE: If you don't want to symlink readlink permanently you may instead
-create a symbolic link to `/path/to/some/bin/readlink` and put that location
+NOTE: If you don't want to symlink readlink and gfind permanently you may instead
+create symbolic links to `/path/to/some/bin/readlink` and `/path/to/somr/bin/find` and put that location
 first in your path when working with this build only.
 
 ### Setting up envionment on Windows


### PR DESCRIPTION
Fixed for macos. Depends on GNU version of `find` so had to install that as well :) 

This should help with #278 on Macos