### PR TITLE
Serve Solr artifacts from localhost through local webserver

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -57,7 +57,7 @@ fi
 if [ "${NOCACHE:-no}" == 'yes' ]; then
   nocache_arg="--no-cache"
 fi
-cmd="docker build --pull --rm=true ${build_arg:-} ${nocache_arg:-} --tag "$IMAGE_NAME:$full_tag" ."
+cmd="docker build --network=host --pull --rm=true ${build_arg:-} ${nocache_arg:-} --tag "$IMAGE_NAME:$full_tag" ."
 echo "running: $cmd"
 $cmd
 extra_tags="$(awk --field-separator ':' '$1 == "'"$relative_dir"'" {print $3}' "$TOP_DIR/TAGS")"

--- a/tools/serve_local.py
+++ b/tools/serve_local.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+#
+# Script which serves local solr tgz files simulating an Apache mirror server
+#
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import os
+import sys
+
+PORT_NUMBER = 8083
+
+#This class will handle any incoming request
+class myHandler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        if self.path.endswith("quit"):
+            print("Exiting")
+            server.socket.close()
+            sys.exit()
+        file = "./downloads/%s" % self.path.split("/")[-1]
+        if not os.path.exists(file):
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(("File %s not found" % file).encode())
+            return
+        try:
+            with open(file, 'rb') as f:
+                size = os.path.getsize(file)
+                self.send_response(200)
+                self.send_header('Content-type', 'application/gzip')
+                self.send_header('Content-length', size)
+                self.end_headers()
+                self.wfile.write(f.read())
+                return
+        except Exception as e:
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(("Error: %s" % e).encode())
+            return
+
+
+try:
+    server = HTTPServer(('', PORT_NUMBER), myHandler)
+    print("Started local web server serving Solr artifacts on port %s" % PORT_NUMBER)
+    server.serve_forever()
+
+except KeyboardInterrupt:
+    print("^C received, shutting down the web server")
+    server.socket.close()

--- a/update.md
+++ b/update.md
@@ -168,6 +168,16 @@ tools/build_all.sh
 This can take a long time, because the builds download the base image, and download the Solr packages again,
 for each image. Subsequent builds can be faster due to Docker's layer caching.
 
+To speed up the build by re-using all the Solr tarballs you have locally in ./downloads already, you can start a local
+webserver serving these binaries and tell the build to use that server instead of the official ASF ones. First, start
+a small webserver in the background, then run the build:
+
+```bash
+tools/serve_local.py &
+SOLR_DOWNLOAD_SERVER="http://host.docker.internal:8083" tools/build_all.sh
+wget -t 1 http://localhost:8083/quit >/dev/null 2>&1
+```
+
 Keep an eye out for "This key is not certified with a trusted signature!"; it would be good to verify the fingerprints with ones you have in your PGP keyring.
 I typically commit key changes separately from version updates.
 


### PR DESCRIPTION
Simple python script which imitates an Apache mirror server, serving the local tar files from ./downloads folder. This speeds up the local build of all images.