### PR TITLE
Fix race condition in wait-for-solr.sh

### DIFF
--- a/5.5/scripts/wait-for-solr.sh
+++ b/5.5/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/5.5/slim/scripts/wait-for-solr.sh
+++ b/5.5/slim/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/6.6/scripts/wait-for-solr.sh
+++ b/6.6/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/6.6/slim/scripts/wait-for-solr.sh
+++ b/6.6/slim/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/7.7/scripts/wait-for-solr.sh
+++ b/7.7/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/7.7/slim/scripts/wait-for-solr.sh
+++ b/7.7/slim/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/8.0/scripts/wait-for-solr.sh
+++ b/8.0/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/8.0/slim/scripts/wait-for-solr.sh
+++ b/8.0/slim/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/8.1/scripts/wait-for-solr.sh
+++ b/8.1/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/8.1/slim/scripts/wait-for-solr.sh
+++ b/8.1/slim/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/8.2/scripts/wait-for-solr.sh
+++ b/8.2/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/8.2/slim/scripts/wait-for-solr.sh
+++ b/8.2/slim/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/8.3/scripts/wait-for-solr.sh
+++ b/8.3/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/8.3/slim/scripts/wait-for-solr.sh
+++ b/8.3/slim/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/8.4/scripts/wait-for-solr.sh
+++ b/8.4/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/8.4/slim/scripts/wait-for-solr.sh
+++ b/8.4/slim/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/8.5/scripts/wait-for-solr.sh
+++ b/8.5/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/8.5/slim/scripts/wait-for-solr.sh
+++ b/8.5/slim/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/scripts-before8/wait-for-solr.sh
+++ b/scripts-before8/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))

--- a/scripts/wait-for-solr.sh
+++ b/scripts/wait-for-solr.sh
@@ -79,7 +79,7 @@ grep -q -E '^https?://' <<<"$solr_url" || usage "--solr-url $solr_url: not a URL
 
 ((attempts_left=max_attempts))
 while (( attempts_left > 0 )); do
-  if wget -q -O - "$solr_url" | grep -q -i solr; then
+  if wget -q -O - "$solr_url" | grep -i solr >/dev/null; then
     break
   fi
   (( attempts_left-- ))


### PR DESCRIPTION
Solve #310.

Script is failing to detect Solr instance as alive due to a race condition between two commands in a pipe.

> `grep -q` succeeds and exits early, causing the still-writing `wget` to fail to write its stdout to the pipe, and the overall pipeline to fail.

Solution is:

> replacing the grep part of the pipeline with just: grep -i solr >/dev/null

I tested it for Solr 8.5.1, under Mac and docker-machine only.

Issue can be reproduced (depending on the environment), using this docker-compose.yml file.

```yaml
version: '3'
services:
  # Solr instance
  solr:
    image: solr:8.5.1
    ports:
      - 8983:8983
  # Should detect Solr running successfully
  solr-success:
    image: solr:8.5.1
    command: bash -c "wait-for-solr.sh --solr-url http://solr:8981"
  # Should not detect Solr, since port is wrong
  solr-fail:
    image: solr:8.5.1
    command: bash -c "wait-for-solr.sh --solr-url http://solr:8980"
```