### PR TITLE
Add the jattach tool

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/5.5/slim/Dockerfile
+++ b/5.5/slim/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/6.6/Dockerfile
+++ b/6.6/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/6.6/slim/Dockerfile
+++ b/6.6/slim/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/7.7/Dockerfile
+++ b/7.7/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/7.7/slim/Dockerfile
+++ b/7.7/slim/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/8.0/slim/Dockerfile
+++ b/8.0/slim/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/8.1/slim/Dockerfile
+++ b/8.1/slim/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/8.2/slim/Dockerfile
+++ b/8.2/slim/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/8.3/slim/Dockerfile
+++ b/8.3/slim/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/8.4/slim/Dockerfile
+++ b/8.4/slim/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/8.5/slim/Dockerfile
+++ b/8.5/slim/Dockerfile
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/Dockerfile-varsolr.template
+++ b/Dockerfile-varsolr.template
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -17,7 +17,10 @@ ARG SOLR_DOWNLOAD_SERVER
 RUN set -ex; \
   apt-get update; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; \
+  cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
+  echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
+  sha512sum -c jattach.sha512; rm jattach.sha512
 
 ENV SOLR_USER="solr" \
     SOLR_UID="8983" \

--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ Instead of using this mechanism, you can of course create your own script that d
 
 Other ways of extending the image are to create custom Docker images that inherit from this one.
 
+## Debugging with jattach
+
+The `jcmd` tool is not included in the JRE. But this image includes the [jattach](https://github.com/apangin/jattach) utility which lets you call `jcmd` and also perform thread dumps and more.
+
 # Updating from Docker-solr5-7 to 8
 
 For Solr 8, the docker-solr distribution switched from just extracting the Solr tar, to using the [service installation script](https://lucene.apache.org/solr/guide/7_7/taking-solr-to-production.html#service-installation-script). This was done for various reasons: to bring it in line with the recommendations by the Solr Ref Guide, to make it easier to mount volumes, and because we were [asked to](https://github.com/docker-solr/docker-solr/issues/173).

--- a/README.md
+++ b/README.md
@@ -236,7 +236,26 @@ Other ways of extending the image are to create custom Docker images that inheri
 
 ## Debugging with jattach
 
-The `jcmd` tool is not included in the JRE. But this image includes the [jattach](https://github.com/apangin/jattach) utility which lets you call `jcmd` and also perform thread dumps and more.
+The `jcmd`, `jmap` `jstack` tools can be useful for debugging Solr inside the container. These tools are not included with the JRE, but this image includes the [jattach](https://github.com/apangin/jattach) utility which lets you do much of the same.
+
+    Usage: jattach <pid> <cmd> [args ...]
+    
+      Commands: 
+        load : load agent library
+        properties : print system properties
+        agentProperties : print agent properties
+        datadump : show heap and thread summary
+        threaddump : dump all stack traces (like jstack)
+        dumpheap : dump heap (like jmap)
+        inspectheap : heap histogram (like jmap -histo)
+        setflag : modify manageable VM flag
+        printflag : print VM flag
+        jcmd : execute jcmd command
+    
+Example comands to do a thread dump and get heap info for PID 10:
+
+    jattach 10 threaddump
+    jattach 10 jcmd GC.heap_info
 
 # Updating from Docker-solr5-7 to 8
 


### PR DESCRIPTION
As discussed in #283. See https://github.com/apangin/jattach

    Usage: jattach <pid> <cmd> [args ...]
    
      Commands: 
        load : load agent library
        properties : print system properties
        agentProperties : print agent properties
        datadump : show heap and thread summary
        threaddump : dump all stack traces (like jstack)
        dumpheap : dump heap (like jmap)
        inspectheap : heap histogram (like jmap -histo)
        setflag : modify manageable VM flag
        printflag : print VM flag
        jcmd : execute jcmd command