### PR TITLE
Require init_var_solr; don't setup in Dockerfile

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.0/scripts/solr-demo
+++ b/8.0/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.0/slim/Dockerfile
+++ b/8.0/slim/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.0/slim/scripts/solr-demo
+++ b/8.0/slim/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.1/scripts/solr-demo
+++ b/8.1/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.1/slim/Dockerfile
+++ b/8.1/slim/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.1/slim/scripts/solr-demo
+++ b/8.1/slim/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.2/scripts/solr-demo
+++ b/8.2/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.2/slim/Dockerfile
+++ b/8.2/slim/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.2/slim/scripts/solr-demo
+++ b/8.2/slim/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.3/scripts/solr-demo
+++ b/8.3/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.3/slim/Dockerfile
+++ b/8.3/slim/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.3/slim/scripts/solr-demo
+++ b/8.3/slim/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.4/scripts/solr-demo
+++ b/8.4/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.4/slim/Dockerfile
+++ b/8.4/slim/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.4/slim/scripts/solr-demo
+++ b/8.4/slim/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.5/scripts/solr-demo
+++ b/8.5/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.5/slim/Dockerfile
+++ b/8.5/slim/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.5/slim/scripts/solr-demo
+++ b/8.5/slim/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.6/Dockerfile
+++ b/8.6/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.6/scripts/solr-demo
+++ b/8.6/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/8.6/slim/Dockerfile
+++ b/8.6/slim/Dockerfile
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/8.6/slim/scripts/solr-demo
+++ b/8.6/slim/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo

--- a/Dockerfile-varsolr.template
+++ b/Dockerfile-varsolr.template
@@ -101,11 +101,7 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chown root:0 /etc/default/solr.in.sh; \
   chmod 0664 /etc/default/solr.in.sh; \
-  mkdir -p /var/solr/data /var/solr/logs; \
-  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
-  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
-  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
-  find /var/solr -type f -print0 | xargs -0 chmod 0660; \
+  mkdir -p -m0770 /var/solr; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
   sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "0:0" /opt/solr-$SOLR_VERSION /docker-entrypoint-initdb.d /opt/docker-solr; \

--- a/scripts/init-var-solr
+++ b/scripts/init-var-solr
@@ -31,31 +31,31 @@ function check_dir_writability {
 }
 
 if [ ! -d "$DIR/data" ]; then
-    echo "Creating $DIR/data"
+    #echo "Creating $DIR/data"
     check_dir_writability "$DIR"
     mkdir "$DIR/data"
     chmod 0770 "$DIR/data"
 fi
 
 if [ ! -d "$DIR/logs" ]; then
-    echo "Creating $DIR/logs"
+    #echo "Creating $DIR/logs"
     check_dir_writability "$DIR"
     mkdir "$DIR/logs"
     chmod 0770 "$DIR/logs"
 fi
 
 if [ ! -f "$DIR/data/solr.xml" ]; then
-    echo "Copying solr.xml"
+    #echo "Copying solr.xml"
     cp -a /opt/solr/server/solr/solr.xml "$DIR/data/solr.xml"
 fi
 
 if [ ! -f "$DIR/data/zoo.cfg" ]; then
-    echo "Copying zoo.cfg"
+    #echo "Copying zoo.cfg"
     cp -a /opt/solr/server/solr/zoo.cfg "$DIR/data/zoo.cfg"
 fi
 
 if [ ! -f "$DIR/log4j2.xml" ]; then
-    echo "Copying log4j2.xml"
+    #echo "Copying log4j2.xml"
     cp -a /opt/solr/server/resources/log4j2.xml "$DIR/log4j2.xml"
 fi
 

--- a/scripts/solr-demo
+++ b/scripts/solr-demo
@@ -8,6 +8,9 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
+# init script for handling an empty /var/solr
+/opt/docker-solr/scripts/init-var-solr
+
 . /opt/docker-solr/scripts/run-initdb
 
 CORE=demo


### PR DESCRIPTION
I propose removing initialization of /var/solr from the Dockerfile, thus leaving only init_var_solr to do this.  The fact that it's in two places means that the image has two solr.xml, two zoo.cfg, two log4j2.xml.  This initialization itself must be maintained twice.  That leads to confusion (it did with my colleagues and I) about which copy is going to be used.  Imagine you are basing your company Solr Dockerfile on top of this one (i.e. official is the FROM) and need to do modifications.  Do you modify /opt/solr/server/solr/solr.xml?  Surprise surprise, _sometimes_ it is copied to /var/solr/data/ by the init_var_solr script but sometimes it isn't because the Dockerfile here will do it, thus ignoring the customizations made to solr.xml in the next image layer.

After making this change, our wonderful tests exposed that solr-demo wasn't invoking init_var_solr.

Is there some reason we should _not_ do this?  There are additional lines printed:
````
Creating /var/solr/data
Creating /var/solr/logs
Copying solr.xml
Copying zoo.cfg
Copying log4j2.xml
````
Perhaps merely a single line "Initializing /var/solr" should be printed if the directory is empty?