### PR TITLE
use an isolated docker network for server_local.py

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -57,7 +57,7 @@ fi
 if [ "${NOCACHE:-no}" == 'yes' ]; then
   nocache_arg="--no-cache"
 fi
-cmd="docker build --network=host --pull --rm=true ${build_arg:-} ${nocache_arg:-} --tag "$IMAGE_NAME:$full_tag" ."
+cmd="docker build --network=${DOCKER_NETWORK:-host} --pull --rm=true ${build_arg:-} ${nocache_arg:-} --tag "$IMAGE_NAME:$full_tag" ."
 echo "running: $cmd"
 $cmd
 extra_tags="$(awk --field-separator ':' '$1 == "'"$relative_dir"'" {print $3}' "$TOP_DIR/TAGS")"

--- a/tools/serve_local.sh
+++ b/tools/serve_local.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Creates an isolated DOCKER_NETWORK in which to run a small docker based webserver hosting the files
+# in the 'downloads' directory on port 8083.  (See serve_local.py)
+#
+# Then executes the command lines args, wrapped with the following variables set...
+#  - DOCKER_NETWORK="docker_solr_serve_local_network" (if name is not overriden by our ENV) 
+#  - SOLR_DOWNLOAD_SERVER="http://docker_solr_serve_local_httpd:9999/" (will be resolvable in our DOCKER_NETWORK)
+# Once the wrapped command finishes, the webserver container & DOCKER_NETWORK will be removed
+# 
+# Examples:
+#    ./tools/serve_local.sh tools/build_all.sh
+#    ./tools/serve_local.sh tools/build.sh 8.7
+#
+
+TOP_DIR="$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/..")"
+
+if (( $# == 0 )); then
+  echo "Usage: $0 some_build_command build-args"
+  exit 1
+fi
+
+PROCESS_STATUS=-1
+
+NETWORK_STATUS=0
+NETWORK_ID=''
+HTTPD_NODE_STATUS=0
+HTTPD_NODE_ID=''
+
+if [[ -z "${DOCKER_NETWORK:-}" ]]; then
+  DOCKER_NETWORK=docker_solr_serve_local_network
+fi
+
+function cleanup_and_exit() {
+  echo "Cleaning up docker HTTPD server and network..."
+  if [[ ! -z "${HTTPD_NODE_ID:-}" ]]; then
+    docker stop $HTTPD_NODE_ID
+    HTTPD_NODE_STATUS=$?
+    if (( 0 != $HTTPD_NODE_STATUS )); then
+      echo "Failed to stop local HTTP server, id: $HTTPD_NODE_ID"
+      PROCESS_STATUS=$HTTPD_NODE_STATUS
+    fi
+  fi
+  if [[ ! -z "${NETWORK_ID:-}" ]]; then
+    docker network rm $DOCKER_NETWORK
+    NETWORK_STATUS=$?
+    if (( 0 != $NETWORK_STATUS )); then
+      echo "Failed to rm docker network $DOCKER_NETWORK"
+      PROCESS_STATUS=$NETWORK_STATUS
+    fi
+  fi
+  exit $PROCESS_STATUS
+}
+trap cleanup_and_exit INT
+
+
+NETWORK_ID=$(docker network create $DOCKER_NETWORK)
+NETWORK_STATUS=$?
+if (( 0 != $NETWORK_STATUS )); then
+  PROCESS_STATUS=$NETWORK_STATUS
+  echo "Failed to create docker network $DOCKER_NETWORK"
+  cleanup_and_exit
+fi
+
+# NOTE: we choose to use network-alias rather then a name for this container, so that our
+# 'host name' is isolated to the DOCKER_NETWORK.
+HTTPD_NODE_ID=$(docker run --rm -d --network $DOCKER_NETWORK --network-alias docker_solr_serve_local_httpd -v $TOP_DIR/downloads:/downloads -v $TOP_DIR/tools:/tools -w / 'python:3-alpine' /tools/serve_local.py)
+
+HTTPD_NODE_STATUS=$?
+if (( 0 != $HTTPD_NODE_STATUS )); then
+  PROCESS_STATUS=$HTTPD_NODE_STATUS
+  echo "Failed to start local HTTP server"
+  cleanup_and_exit
+fi
+
+# now run our 'inner' process...
+DOCKER_NETWORK=$DOCKER_NETWORK SOLR_DOWNLOAD_SERVER="http://docker_solr_serve_local_httpd:8083/" "$@"
+PROCESS_STATUS=$?
+
+cleanup_and_exit

--- a/update.md
+++ b/update.md
@@ -163,17 +163,15 @@ tools/build_all.sh
 This can take a long time, because the builds download the base image, and download the Solr packages again,
 for each image. Subsequent builds can be faster due to Docker's layer caching.
 
-To speed up the build by re-using all the Solr tarballs you have locally in ./downloads already, you can start a local
-webserver serving these binaries and tell the build to use that server instead of the official ASF ones. First, start
-a small webserver in the background, then run the build:
+To speed up the build by re-using all the Solr tarballs you have locally in ./downloads already, you can wrap your
+build command using `tools/serve_local.sh` which will create a temporary docker network, run a webserver serving these
+binaries in that network, and configure the build command(s) to use that network+server instead of fetching from the
+official ASF `DOWNLOAD_SERVER`.
+
 
 ```bash
-tools/serve_local.py &
-SOLR_DOWNLOAD_SERVER="http://host.docker.internal:8083" tools/build_all.sh
-wget -t 1 http://localhost:8083/quit >/dev/null 2>&1
+./tools/serve_local.sh .tools/build_all.sh
 ```
-
-*Note: "host.docker.internal" is supported on macOS & Windows, but perhaps not anywhere else.  Try "localhost".*
 Keep an eye out for "This key is not certified with a trusted signature!"; it would be good to verify the fingerprints with ones you have in your PGP keyring.
 I typically commit key changes separately from version updates.
 


### PR DESCRIPTION
Having learned a bit more about docker networking since #352 i realized a simple way to solve the issue of running `serve_local.py` in a cross platform way would be to run it in it's own docker container, on an isolated docker network (added bonus: doesn't care if the port is already in use on the docker host)

I implemented a 'wrapper' script to handle spinning up the network & httpd docker container, and shut them down automatically when the build command is finished.

Examples:
```
./tools/serve_local.sh tools/build_all.sh

./tools/serve_local.sh tools/build.sh 8.7
```