### PR TITLE
Update Readme for solrdata permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is a convenient mechanism for developers, and could be used for single-serv
 
 ```console
 $ mkdir solrdata
+$ sudo chown 8983:8983 solrdata
 $ docker run -d -v "$PWD/solrdata:/var/solr" -p 8983:8983 --name my_solr solr:8 solr-precreate gettingstarted
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a convenient mechanism for developers, and could be used for single-serv
 
 ```console
 $ mkdir solrdata
-$ sudo chown 8983:8983 solrdata
+$ sudo chown 8983:8983 solrdata  # necessary on Linux, not Mac.
 $ docker run -d -v "$PWD/solrdata:/var/solr" -p 8983:8983 --name my_solr solr:8 solr-precreate gettingstarted
 ```
 


### PR DESCRIPTION
I added a command the to show that the solrdata directory on the host must have the proper permissions to be accessible by the solr user inside the container. In this case, I have done so by changing the user on the host to the same UID as the solr user in the container.