### PR TITLE
run `apt-get -y upgrade` on build.

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -16,6 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
+  apt-get -y upgrade; \
   apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \


### PR DESCRIPTION
Simply running `apt-get update` does not not apply the latest security updates from the Debian---it only refreshes the package index. I would like to build my images locally specifically so I can run on an up-to-date system, but for that, `apt-get upgrade` must also run at build time.