### PR TITLE
Special case older solr versions to use hard coded architectures

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -114,6 +114,11 @@ for version in "${versions[@]}"; do
 		variantParent="$(awk 'toupper($1) == "FROM" { print $2 }' "$dir/Dockerfile")"
 		variantArches="${parentRepoToArches[$variantParent]}"
 
+    # we don't support the full range of possible archs for these legacy versions...
+    if [[ $version == 6.* ]] || [[ $version == 5.* ]] ; then
+       variantArches="amd64"
+    fi
+    
 		echo
 		cat <<-EOE
 			Tags: $(sed -E 's/ +/, /g' <<<"${variantAliases[@]}")


### PR DESCRIPTION
Per comments from smiley on the solr dev list...

> Regarding the arm64v8 tags, those should be removed manually, or fix the
root cause that probably lies in that generate-stackbrew-library.sh
script.  See the PR comments about that here:
https://github.com/docker-library/official-images/pull/10403
