### PR TITLE
Disable log4j message lookup in SOLR_OPTS (CVE-2021-44228)

### DIFF
--- a/5.5/scripts/start-local-solr
+++ b/5.5/scripts/start-local-solr
@@ -13,7 +13,7 @@ MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
 eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | grep -E '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
 MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
-MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true"
 
 if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
     echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"

--- a/5.5/slim/scripts/start-local-solr
+++ b/5.5/slim/scripts/start-local-solr
@@ -13,7 +13,7 @@ MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
 eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | grep -E '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
 MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
-MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true"
 
 if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
     echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"

--- a/6.6/scripts/start-local-solr
+++ b/6.6/scripts/start-local-solr
@@ -13,7 +13,7 @@ MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
 eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | grep -E '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
 MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
-MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true"
 
 if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
     echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"

--- a/6.6/slim/scripts/start-local-solr
+++ b/6.6/slim/scripts/start-local-solr
@@ -13,7 +13,7 @@ MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
 eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | grep -E '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
 MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
-MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true"
 
 if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
     echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"

--- a/7.7/scripts/start-local-solr
+++ b/7.7/scripts/start-local-solr
@@ -13,7 +13,7 @@ MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
 eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | grep -E '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
 MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
-MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true"
 
 if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
     echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"

--- a/7.7/slim/scripts/start-local-solr
+++ b/7.7/slim/scripts/start-local-solr
@@ -13,7 +13,7 @@ MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
 eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | grep -E '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
 MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
-MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true"
 
 if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
     echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"

--- a/8.0/scripts/start-local-solr
+++ b/8.0/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.0/slim/scripts/start-local-solr
+++ b/8.0/slim/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.1/scripts/start-local-solr
+++ b/8.1/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.1/slim/scripts/start-local-solr
+++ b/8.1/slim/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.10/scripts/start-local-solr
+++ b/8.10/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.10/slim/scripts/start-local-solr
+++ b/8.10/slim/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.11/scripts/start-local-solr
+++ b/8.11/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.11/slim/scripts/start-local-solr
+++ b/8.11/slim/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.2/scripts/start-local-solr
+++ b/8.2/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.2/slim/scripts/start-local-solr
+++ b/8.2/slim/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.3/scripts/start-local-solr
+++ b/8.3/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.3/slim/scripts/start-local-solr
+++ b/8.3/slim/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.4/scripts/start-local-solr
+++ b/8.4/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.4/slim/scripts/start-local-solr
+++ b/8.4/slim/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.5/scripts/start-local-solr
+++ b/8.5/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.5/slim/scripts/start-local-solr
+++ b/8.5/slim/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.6/scripts/start-local-solr
+++ b/8.6/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.6/slim/scripts/start-local-solr
+++ b/8.6/slim/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.7/scripts/start-local-solr
+++ b/8.7/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.7/slim/scripts/start-local-solr
+++ b/8.7/slim/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.8/scripts/start-local-solr
+++ b/8.8/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.8/slim/scripts/start-local-solr
+++ b/8.8/slim/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.9/scripts/start-local-solr
+++ b/8.9/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/8.9/slim/scripts/start-local-solr
+++ b/8.9/slim/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/TAGS
+++ b/TAGS
@@ -1,3 +1,5 @@
+8.11:8.11.0:8.11 8 latest
+8.11/slim:8.11.0-slim:8.11-slim 8-slim latest-slim
 8.10:8.10.1:8.10
 8.10/slim:8.10.1-slim:8.10-slim
 8.9:8.9.0:8.9
@@ -26,5 +28,3 @@
 6.6/slim:6.6.6-slim:6.6-slim 6-slim
 5.5:5.5.5:5.5 5
 5.5/slim:5.5.5-slim:5.5-slim 5-slim
-8.11:8.11.0:8.11 8 latest
-8.11/slim:8.11.0-slim:8.11-slim 8-slim latest-slim

--- a/scripts-before8/start-local-solr
+++ b/scripts-before8/start-local-solr
@@ -13,7 +13,7 @@ MY_SOLR_INCLUDE="${SOLR_INCLUDE:-/opt/solr/bin/solr.in.sh}"
 eval "$( set +e +u +o pipefail; . "$MY_SOLR_INCLUDE"; set -o posix; set | grep -E '^SOLR_(LOGS_DIR|OPTS)=' | sed 's/^SOLR_/MY_SOLR_/')"
 
 MY_SOLR_LOGS_DIR="${MY_SOLR_LOGS_DIR:-/opt/solr/server/logs}"
-MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
+MY_SOLR_OPTS="${MY_SOLR_OPTS:-} -Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true"
 
 if [ ! -w "$MY_SOLR_LOGS_DIR" ]; then
     echo "Log directory $MY_SOLR_LOGS_DIR is not writable by $(id -u):$(id -g)"

--- a/scripts/start-local-solr
+++ b/scripts/start-local-solr
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost} -Dlog4j2.formatMsgNoLookups=true" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then


### PR DESCRIPTION
To mitigate CVE-2021-44228 as instructed at https://solr.apache.org/security.html#apache-solr-affected-by-apache-log4j-cve-2021-44228. 