### PR TITLE
More brutal CVE-2021-45046 mitigation

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -86,6 +86,10 @@ RUN set -ex; \
   mv "/opt/solr-$SOLR_VERSION" /opt/solr; \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   mkdir -p /opt/solr/server/solr/mycores /opt/solr/server/logs /opt/mysolrhome; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \

--- a/5.5/slim/Dockerfile
+++ b/5.5/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -86,6 +86,10 @@ RUN set -ex; \
   mv "/opt/solr-$SOLR_VERSION" /opt/solr; \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   mkdir -p /opt/solr/server/solr/mycores /opt/solr/server/logs /opt/mysolrhome; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \

--- a/6.6/Dockerfile
+++ b/6.6/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -86,6 +86,10 @@ RUN set -ex; \
   mv "/opt/solr-$SOLR_VERSION" /opt/solr; \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   mkdir -p /opt/solr/server/solr/mycores /opt/solr/server/logs /opt/mysolrhome; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \

--- a/6.6/slim/Dockerfile
+++ b/6.6/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -86,6 +86,10 @@ RUN set -ex; \
   mv "/opt/solr-$SOLR_VERSION" /opt/solr; \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   mkdir -p /opt/solr/server/solr/mycores /opt/solr/server/logs /opt/mysolrhome; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \

--- a/7.7/Dockerfile
+++ b/7.7/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -86,6 +86,10 @@ RUN set -ex; \
   mv "/opt/solr-$SOLR_VERSION" /opt/solr; \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   mkdir -p /opt/solr/server/solr/mycores /opt/solr/server/logs /opt/mysolrhome; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \

--- a/7.7/slim/Dockerfile
+++ b/7.7/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -86,6 +86,10 @@ RUN set -ex; \
   mv "/opt/solr-$SOLR_VERSION" /opt/solr; \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   mkdir -p /opt/solr/server/solr/mycores /opt/solr/server/logs /opt/mysolrhome; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.0/slim/Dockerfile
+++ b/8.0/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.1/slim/Dockerfile
+++ b/8.1/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.10/Dockerfile
+++ b/8.10/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.10/slim/Dockerfile
+++ b/8.10/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.11/Dockerfile
+++ b/8.11/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.11/slim/Dockerfile
+++ b/8.11/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.2/slim/Dockerfile
+++ b/8.2/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.3/slim/Dockerfile
+++ b/8.3/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.4/slim/Dockerfile
+++ b/8.4/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.5/slim/Dockerfile
+++ b/8.5/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.6/Dockerfile
+++ b/8.6/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.6/slim/Dockerfile
+++ b/8.6/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.7/Dockerfile
+++ b/8.7/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.7/slim/Dockerfile
+++ b/8.7/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.8/Dockerfile
+++ b/8.8/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.8/slim/Dockerfile
+++ b/8.8/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.9/Dockerfile
+++ b/8.9/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/8.9/slim/Dockerfile
+++ b/8.9/slim/Dockerfile
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/Dockerfile-varsolr.template
+++ b/Dockerfile-varsolr.template
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -91,6 +91,10 @@ RUN set -ex; \
   (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   chown -R 0:0 "/opt/solr-$SOLR_VERSION"; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -16,7 +16,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini zip; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v1.5/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "d8eedbb3e192a8596c08efedff99b9acf1075331e1747107c07cdb1718db2abe259ef168109e46bd4cf80d47d43028ff469f95e6ddcbdda4d7ffa73a20e852f9  jattach"; \
@@ -86,6 +86,10 @@ RUN set -ex; \
   mv "/opt/solr-$SOLR_VERSION" /opt/solr; \
   rm "/opt/solr-$SOLR_VERSION.tgz"*; \
   rm -Rf /opt/solr/docs/ /opt/solr/dist/{solr-core-$SOLR_VERSION.jar,solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
+  # https://nvd.nist.gov/vuln/detail/CVE-2021-45046. Remove
+  # JndiLookup.class from all log4j jars. Do not error if it is not in
+  # the jar and zip has nothing do to.
+  find . -name 'log4j-core*.jar' | xargs -I{} sh -c 'zip -q -d "$1" org/apache/logging/log4j/core/lookup/JndiLookup.class || [ "$?" -eq 12 ]' -s {}; \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d /opt/docker-solr; \
   mkdir -p /opt/solr/server/solr/mycores /opt/solr/server/logs /opt/mysolrhome; \
   sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \


### PR DESCRIPTION
See #398.

This is my attempt to apply the fix from CVE-2021-45046, which advises:

> This issue can be mitigated in prior releases (< 2.16.0) by removing the JndiLookup class from the classpath (example: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class).

I think one of the following must be true:
- Solr makes no use of this code anyway. So this change is both non-breaking (there is no functionality to break) and unnecessary (there are no security holes that this fixes)
- Solr does make use of this code. So this change is both potentially breaking (it may break/change whatever behaviour relies on this code) and necessary (there is a security hole that this fixes, namely CVE-2021-45046)

I think that which of these is true depends on whether the analysis of Solr that the original mitigation for CVE-2021-44228 is sufficient. If it is, then the former is true, otherwise the latter.

My view is that in either case, the Solr docker image is better with this change applied, hence my opening of this PR. I appreciate there may well be concerns about this change (hacking some `jar`s with zip :shrug:, maybe it will break other things for reasons I don't understand, maybe the risk of breaking some legitimate uses of JndiLookup outweigh the perceived risks of the security flaw, maybe Solr releases are inbound to bump log4j to 2.16.0).

Also, I have only tested that with this change, I can run `./tools/build_latest.sh` and the docker build succeeds, and that when I run the image it built, it seems to start Solr and I can see the Solr UI in a browser.