### PR TITLE
Mac toolchain updates

### DIFF
--- a/tools/init_macos.sh
+++ b/tools/init_macos.sh
@@ -1,13 +1,26 @@
 # Source this file to prepare a mac for running scripts
-hash greadlink 2>/dev/null || { echo >&2 "Required tool greadlink is not installed, please run 'brew install coreutils'"; exit 1; }
-hash gfind 2>/dev/null || { echo >&2 "Required tool gfind is not installed, please run 'brew install findutils'"; exit 1; }
-hash gsed 2>/dev/null || { echo >&2 "Required tool gsed is not installed, please run 'brew install gnu-sed'"; exit 1; }
+hash greadlink 2>/dev/null || {
+  echo >&2 "Required tool greadlink is not installed, please run 'brew install coreutils'"
+  exit 1
+}
+hash gfind 2>/dev/null || {
+  echo >&2 "Required tool gfind is not installed, please run 'brew install findutils'"
+  exit 1
+}
+hash gsed 2>/dev/null || {
+  echo >&2 "Required tool gsed is not installed, please run 'brew install gnu-sed'"
+  exit 1
+}
+
+TOOL_PREFIX="$(brew --prefix)/bin"
+
 if [[ ! -d /tmp/docker-solr-bin ]]; then
   mkdir -p /tmp/docker-solr-bin >/dev/null 2>&1
-  ln -s /usr/local/bin/greadlink /tmp/docker-solr-bin/readlink
-  ln -s /usr/local/bin/gfind /tmp/docker-solr-bin/find
-  ln -s /usr/local/bin/gsed /tmp/docker-solr-bin/sed
+  ln -s $TOOL_PREFIX/greadlink /tmp/docker-solr-bin/readlink
+  ln -s $TOOL_PREFIX/gfind /tmp/docker-solr-bin/find
+  ln -s $TOOL_PREFIX/gsed /tmp/docker-solr-bin/sed
 fi
+
 if [[ ! $PATH == *"docker-solr-bin"* ]]; then
   export PATH=/tmp/docker-solr-bin:$PATH
   echo "Configuring for macOS - adding /tmp/docker-solr-bin first in path"

--- a/update.md
+++ b/update.md
@@ -102,12 +102,13 @@ You also need the GNU version of some tools.
 ```bash
 brew install gpg  # If you don't have GPG already
 brew install git  # If you don't have git already
-brew install coreutils wget gawk shellcheck bash parallel findutils  # Other dependencies
+brew install coreutils wget gawk shellcheck bash parallel findutils gnu-sed  # Other dependencies
 sudo wget -nv --output-document=/usr/local/bin/bashbrew https://github.com/docker-library/bashbrew/releases/download/v0.1.1/bashbrew-darwin-amd64
 sudo chmod a+x /usr/local/bin/bashbrew
 ```
 
 Before you start running scripts, please run an init script that puts GNU tools first in PATH. The settings only takes effect for the current Terminal window:
+
 ```bash
 source tools/init_macos.sh
 ```


### PR DESCRIPTION
This has two minor changes to the build process on macOS which I encountered while working on #405:

* Add the `gnu-sed` requirement to update.md to avoid an error round-trip
* Support Homebrew's [default prefix change for ARM](https://docs.brew.sh/FAQ#why-should-i-install-homebrew-in-the-default-location)